### PR TITLE
Changed Angular Version to fix Travis Errors.

### DIFF
--- a/ui/bower.json
+++ b/ui/bower.json
@@ -21,7 +21,7 @@
   },
   "devDependencies": {},
   "resolutions": {
-    "angular":"1.6.2",
+    "angular":"1.6.3",
     "angular-moment": "1.0.0-beta.3"
   },
   "overrides": {


### PR DESCRIPTION
`Uncaught TypeError: angular.module (...).info` is new functionality in 1.6.3, prior to that, 1.5.11 did not have .info. Recently all bower packages were bumped unto 1.6.3 , but our repository runs on angular 1.6.2 , so that was causing Travis error and dependency conflicts . One of the solution was to restrict all packages to use 1.6.2 , or simply bump angular to 1.6.3 . This should resolve the conflicts.
This should solve the conflicts during bower install and testing in Travis.