### PR TITLE
Keep aria hostname to the config file

### DIFF
--- a/components/core/DownloadDaemon.py
+++ b/components/core/DownloadDaemon.py
@@ -235,7 +235,7 @@ def starter(socket):
     remove_files(conf['max_age'], conf['min_rating'])
     folder_size=get_size(conf['down_folder'])
     websocket.enableTrace(False)
-    ws = websocket.WebSocketApp("ws://localhost:6800/jsonrpc",
+    ws = websocket.WebSocketApp(conf['aria_server'],
                                 on_message=on_message,
                                 on_error=on_error,
                                 on_close=on_close)

--- a/components/core/dl.conf
+++ b/components/core/dl.conf
@@ -1,1 +1,1 @@
-{"max_downloads": 2, "down_folder": "download/file/path", "size_limit":100000, "max_age":1, "min_rating":3, "max_bandwidth": 300000}
+{"max_downloads": 2, "down_folder": "download/file/path", "size_limit":100000, "max_age":1, "min_rating":3, "max_bandwidth": 300000, "aria_server": "ws://localhost:6800/jsonrpc"}

--- a/ui/src/app/admin/services/AdminService.spec.js
+++ b/ui/src/app/admin/services/AdminService.spec.js
@@ -27,7 +27,6 @@ describe("Service: AdminService", function() {
       expect(response.data.status).toEqual("12345");
     });
 
-    localHttpBackend.flush();
   });
 
   it("should kill downloads", function() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
* Move the hard-coded aria2 server's hostname:port to a config file
* Fix the failing test case on angular-mocks#1.6.7

## Related Issue
None

## Motivation and Context
* Keeps the code cleaner. 
* Will make it easier to dockerize bassa

## How Has This Been Tested?
Manual testing

## Screenshots (In case of UI changes):
None

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
