### PR TITLE
Add setup-mysql.sh

### DIFF
--- a/scripts/debian/setup-mysql.sh
+++ b/scripts/debian/setup-mysql.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+mysql_root_password='s57d46857f968t79pho';
+bassa_db_name='bassa'
+bassa_user_name='bassa'
+bassa_user_password='678yU8O7T87ihu7HU9797U'
+echo "";
+echo "Installing MySQL on Debian based Linux"
+echo "";
+sudo apt-get update;
+sudo debconf-set-selections <<< 'mysql-server mysql-server/root_password password '$mysql_root_password;
+sudo debconf-set-selections <<< 'mysql-server mysql-server/root_password_again password '$mysql_root_password;
+sudo apt-get -y install mysql-server;
+echo "";
+echo "MySQL Installed Successfully";

--- a/scripts/debian/setup-mysql.sh
+++ b/scripts/debian/setup-mysql.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 mysql_root_password='s57d46857f968t79pho';
-bassa_db_name='bassa'
-bassa_user_name='bassa'
-bassa_user_password='678yU8O7T87ihu7HU9797U'
+port="3006";
 echo "";
 echo "Installing MySQL on Debian based Linux"
 echo "";
@@ -10,5 +8,8 @@ sudo apt-get update;
 sudo debconf-set-selections <<< 'mysql-server mysql-server/root_password password '$mysql_root_password;
 sudo debconf-set-selections <<< 'mysql-server mysql-server/root_password_again password '$mysql_root_password;
 sudo apt-get -y install mysql-server;
+sudo sed -i "s/port.*/port = $port/" /etc/mysql/mysql.conf.d/mysqld.cnf;
+sudo service mysql stop;
+sudo service mysql start;
 echo "";
 echo "MySQL Installed Successfully";


### PR DESCRIPTION
## setup-mysql.sh
This shell script is used to install mysql in a non-interactive way. The password is also set using a variable.
The user needs to run only 1 command in the terminal-  `./scripts/debian/setup-mysql.sh`

**The screenshot shows that the installation shell script changes the default port to one that is saved in a variable (3006)**
![proof](https://user-images.githubusercontent.com/19776024/34340646-089524e4-e9ae-11e7-9d77-daaeea6eca38.png)