### PR TITLE
Add setup.sh

### DIFF
--- a/scripts/debian/setup.sh
+++ b/scripts/debian/setup.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-echo "Setting up Bassa on Debian bases Linux";
+echo "Setting up Bassa on Debian based Linux";

--- a/scripts/debian/setup.sh
+++ b/scripts/debian/setup.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+echo "Setting up Bassa on Debian bases Linux";

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+distro=$(cat /etc/*-release | grep "DISTRIB_ID=" | cut -d"=" -f2);
+privilege=$(whoami);
+if [ $privilege = 'root' ]; then
+	echo "Root privileges allowed"
+	if [ $distro = "Debian" ]; then 
+		./debian/setup.sh
+  	else
+		echo "Setting up Bassa on not Debian bases Linux"
+	fi
+else
+	echo "Run the terminal with root privileges"
+	sleep 2
+	exit		
+fi


### PR DESCRIPTION
## Add setup.sh in scripts directory
[GCI 2017]

I've made the script according to the conditions stated in the task-
```
Create a directory called scripts/debian/ and create a file as setup.sh there also, 
and add echo "Setting up Bassa on Debian bases Linux".

scripts/setup.sh should do the following
1) Check if the terminal has root permission. If not exit the terminal after showing
   message asking the user to run with root privileges
2) Find the Linux distribution of the current machine and store it in a variable
3) Check if the Linux distribution of the machine is debian, if so execute the 
   file located in scripts/debian/setup.sh
```

**Working of script in all scenarios:**
![bassasetupsh](https://user-images.githubusercontent.com/19776024/34342997-39697716-e9e8-11e7-9563-3efff3461162.png)
