### PR TITLE
Update Signup requests tab in real-time

### DIFF
--- a/components/core/DBCon.py
+++ b/components/core/DBCon.py
@@ -7,7 +7,8 @@ def get_db_con () :
     global _db
     if _db==None:
         try:
-            _db=MySQLdb.connect("db", os.environ.get('BASSA_DB_USERNAME'), os.environ.get('BASSA_DB_PASSWORD'), os.environ.get('BASSA_DB_NAME'))
+            #_db=MySQLdb.connect("db", os.environ.get('BASSA_DB_USERNAME'), os.environ.get('BASSA_DB_PASSWORD'), os.environ.get('BASSA_DB_NAME'))
+            _db=MySQLdb.connect("localhost", "bassaman", "s57d46857f968t79pho", "Bassa")
             return _db
         except:
             return None

--- a/components/core/DBCon.py
+++ b/components/core/DBCon.py
@@ -7,8 +7,7 @@ def get_db_con () :
     global _db
     if _db==None:
         try:
-            #_db=MySQLdb.connect("db", os.environ.get('BASSA_DB_USERNAME'), os.environ.get('BASSA_DB_PASSWORD'), os.environ.get('BASSA_DB_NAME'))
-            _db=MySQLdb.connect("localhost", "bassaman", "s57d46857f968t79pho", "Bassa")
+            _db=MySQLdb.connect("db", os.environ.get('BASSA_DB_USERNAME'), os.environ.get('BASSA_DB_PASSWORD'), os.environ.get('BASSA_DB_NAME'))
             return _db
         except:
             return None

--- a/ui/src/app/admin/controllers/AdminCtrl.js
+++ b/ui/src/app/admin/controllers/AdminCtrl.js
@@ -45,10 +45,10 @@
       });
     };
 
-    $scope.approve = function(username) {
-      AdminService.approve(username.user_name).then(function (response) {
-        ToastService.showToast('Approved', username.user_name);
-        $scope.signup_requests.splice(username, 1);
+    $scope.approve = function(user) {
+      AdminService.approve(user.user_name).then(function (response) {
+        ToastService.showToast('Approved', user.user_name);
+        $scope.signup_requests.splice(user, 1);
         getRequests();
       }, function(error){
         ToastService.showToast('Oops! Something went wrong');

--- a/ui/src/app/admin/controllers/AdminCtrl.js
+++ b/ui/src/app/admin/controllers/AdminCtrl.js
@@ -46,8 +46,9 @@
     };
 
     $scope.approve = function(username) {
-      AdminService.approve(username).then(function (response) {
-        ToastService.showToast('Approved', username);
+      AdminService.approve(username.user_name).then(function (response) {
+        ToastService.showToast('Approved', username.user_name);
+        $scope.signup_requests.splice(username, 1);
         getRequests();
       }, function(error){
         ToastService.showToast('Oops! Something went wrong');

--- a/ui/src/app/admin/controllers/AdminCtrl.spec.js
+++ b/ui/src/app/admin/controllers/AdminCtrl.spec.js
@@ -57,7 +57,7 @@ describe('Controller: Admin controller', function() {
         password: 'bassapass'
     }
 
-    scope.approve();
+    scope.approve(user);
   
     expect(AdminService.approve).toHaveBeenCalled();
   

--- a/ui/src/app/admin/controllers/AdminCtrl.spec.js
+++ b/ui/src/app/admin/controllers/AdminCtrl.spec.js
@@ -50,6 +50,13 @@ describe('Controller: Admin controller', function() {
 
     spyOn(AdminService, 'approve').and.callFake(fakeHttpPromise);
   
+
+    var user = {
+        user_name: 'BassaUser',
+        email: 'user@bassa.com',
+        password: 'bassapass'
+    }
+
     scope.approve();
   
     expect(AdminService.approve).toHaveBeenCalled();

--- a/ui/src/app/views/admin.html
+++ b/ui/src/app/views/admin.html
@@ -23,7 +23,7 @@
             <td data-title="Name">{{data.user_name}}</td>
             <td data-title="Email">{{data.email}}</td>
             <td id="approve-btn">
-              <md-button class="md-raised" ng-click="approve(data.user_name)">
+              <md-button class="md-raised" ng-click="approve(data)">
                   <i class="material-icons">done</i>
               </md-button>
             </td>

--- a/ui/src/app/views/admin.html
+++ b/ui/src/app/views/admin.html
@@ -18,12 +18,12 @@
 
     <table id="table" class="table table-hover table-bordered signup-requests-table">
         <tbody>
-        <tr ng-repeat="data in signup_requests" ng-hide="number_to_approve == $index">
+        <tr ng-repeat="data in signup_requests">
             <td data-title="ID">{{$index + 1}}</td>
             <td data-title="Name">{{data.user_name}}</td>
             <td data-title="Email">{{data.email}}</td>
             <td id="approve-btn">
-              <md-button class="md-raised" ng-click="approve(data.user_name); number_to_approve = $index">
+              <md-button class="md-raised" ng-click="approve(data.user_name)">
                   <i class="material-icons">done</i>
               </md-button>
             </td>

--- a/ui/src/app/views/admin.html
+++ b/ui/src/app/views/admin.html
@@ -18,12 +18,12 @@
 
     <table id="table" class="table table-hover table-bordered signup-requests-table">
         <tbody>
-        <tr ng-repeat="data in signup_requests">
+        <tr ng-repeat="data in signup_requests" ng-hide="number_to_approve == $index">
             <td data-title="ID">{{$index + 1}}</td>
             <td data-title="Name">{{data.user_name}}</td>
             <td data-title="Email">{{data.email}}</td>
             <td id="approve-btn">
-              <md-button class="md-raised" ng-click="approve(data.user_name)">
+              <md-button class="md-raised" ng-click="approve(data.user_name); number_to_approve = $index">
                   <i class="material-icons">done</i>
               </md-button>
             </td>


### PR DESCRIPTION
The entire Bassa site works on a real-time basis which makes the user experience a whole lot better. This had not been implemented in the area of the admin approving a signup request from a new user. 
Now, when the admin approves a signup request, the request disappears from the page and hence it is updated in real-time

View the working demonstration of this [here](https://drive.google.com/file/d/1CcO7PfMnlY6CoaEFlVIQP8b04yse7U6q/view?usp=sharing)