### PR TITLE
Changing the name to correct setup file, in readme.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ First clone the Repository
 Use python 3 instead of Python 2
 
 ```
-  $ sudo sh start.sh
+  $ sudo sh setup.sh
   $ cd components/core/
   $ sudo python setup.py develop
 ```


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->
Changes in readme.md
## Description
<!--- Describe your changes in detail -->
 Line `sudo sh start.sh` is replaced by `sudo sh setup.sh` in [README.md](https://github.com/scorelab/Bassa/blob/master/README.md), because there is no file named, `start.sh`, in the main directory.

<!--## Related Issue--.
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

<!--## Motivation and Context-->

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
This is a simple `README.md` change so no need for code testing
## Screenshots (In case of UI changes):



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--Signed off -- Nirmal Sarswat nirmalsarswat400@gmail.com-->