### PR TITLE
Fix node8 broken package error

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -102,7 +102,7 @@
     "jasmine-reporters": "2.0.7",
     "postcss": "^5.1.2",
     "prettier": "^1.2.2",
-    "require-dir": "~0.3.0",
+    "require-dir": "~1.0.0",
     "uglify-save-license": "~0.4.1",
     "wiredep": "~2.2.0"
   },


### PR DESCRIPTION
This PR fixes the error #432 . Here the updated version of `require-dir` node package was included in package.json