### PR TITLE
Add download by pressing Enter key

### DIFF
--- a/ui/src/app/dashboard/controllers/DashCtrl.js
+++ b/ui/src/app/dashboard/controllers/DashCtrl.js
@@ -52,6 +52,11 @@
         });
       }
     };
+    
+    $scope.addDownload = function(keyEvent) {
+  if (keyEvent.which === 13)
+    $scope.addLink();
+  }
     var getActiveDownloads = function() {
       DashService.getDownloads().then(function (response) {
         var data = response.data;

--- a/ui/src/app/views/dashboard.html
+++ b/ui/src/app/views/dashboard.html
@@ -1,9 +1,9 @@
 <div layout-gt-md="column" layout-align="center">
 
   <md-content class="add-download-box" >
-    <md-input-container flex class="downlod-input-box">
+    <md-input-container flex class="downlod-input-box" ng-keyup="addDownload($event)">
         <label>Add download</label>
-        <input ng-model="dlink.link" name="taskText" type="text" required>
+        <input ng-model="dlink.link" name="taskText" type="text" required >
     </md-input-container>
     <md-button class="md-fab md-wayrn md-mini" ng-click="addLink()">
         <i class="material-icons">add</i>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Add download by pressing enter key.
## Description
<!--- Describe your changes in detail -->
In Bassa dashboard user can add download by pressing enter key instead of just clicking fab button only.
It is user friendly for users.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/scorelab/Bassa/issues/443

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
In a localhost of ubuntu pc.

## Screenshots (In case of UI changes):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
