### PR TITLE
Import pip functionality according to version in setup file

### DIFF
--- a/components/core/setup.py
+++ b/components/core/setup.py
@@ -3,7 +3,11 @@ import shutil
 import inspect
 import platform
 from setuptools import setup
-from pip.req import parse_requirements
+
+try:
+    from pip.req import parse_requirements
+except ImportError:
+    from pip._internal.req import parse_requirements
 
 EMAIL_CONF = 'email.conf'
 DL_CONF = 'dl.conf'


### PR DESCRIPTION
#### Bug Fix
<!--- Provide a general summary of your changes in the Title above -->

## Description
Bassa setup fails with `python3 setup.py develop` on pip@10. In this PR, I have added import statement of pip according to version check 😀 
<!--- Describe your changes in detail -->

## Related Issue
#466 
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested?
Setup Bassa on different Linux machine with updated setup file
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
