### PR TITLE
Download input field now goes to default state when a download link is added (fixes #484)

### DIFF
--- a/ui/src/app/views/dashboard.html
+++ b/ui/src/app/views/dashboard.html
@@ -3,7 +3,7 @@
   <md-content class="add-download-box" >
     <md-input-container flex class="downlod-input-box" ng-keyup="addDownload($event)">
         <label>Add download</label>
-        <input ng-model="dlink.link" name="taskText" type="text" required >
+        <input ng-model="dlink.link" name="taskText" type="text">
     </md-input-container>
     <md-button class="md-fab md-wayrn md-mini" ng-click="addLink()">
         <i class="material-icons">add</i>


### PR DESCRIPTION
The updated code fixes the issue!

Check the following screenshot to see :

![ui-patch-1](https://user-images.githubusercontent.com/16841267/46260375-8eba9880-c502-11e8-90e8-65676c477fcc.gif)
