### PR TITLE
Reminder to get 'Go' from maintainers before a PR

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -30,3 +30,7 @@
 * Environment name and version (e.g. Chrome 39, node.js 5.4):
 * Operating System and version (desktop or mobile):
 * Link to your project:
+
+
+# Pull Requests to this issue
+If you are planning to create a PR for this issue, please make sure you first discuss with the maintainers of the project about ths issue well and get the 'Go' from them first.


### PR DESCRIPTION
We see a lot of first-time contributors creating issues and developing them without properly discussing with the project maintainers. 

This is sometimes problematic, thus reminding the issue creators to first have a good discussion with maintainers is a good way to avoid this.