### PR TITLE
Update setup.py to be compatible with pip10

### DIFF
--- a/components/core/setup.py
+++ b/components/core/setup.py
@@ -3,7 +3,10 @@ import shutil
 import inspect
 import platform
 from setuptools import setup
-from pip.req import parse_requirements
+try: # for pip >= 10
+    from pip._internal.req import parse_requirements
+except ImportError: # for pip <= 9.0.3
+    from pip.req import parse_requirements
 
 EMAIL_CONF = 'email.conf'
 DL_CONF = 'dl.conf'


### PR DESCRIPTION
Setup.py is now compatible with pip10



## Description
Setup.py was not compatible with pip version 10. 


## Motivation and Context
Could not run setup.py - was giving import error
