### PR TITLE
Add Gabriellyan Catheline as Contributor

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -2,3 +2,4 @@ CONTRIBUTORS
 ============
 
  - Milindu Sanoj Kumarage (agentmilindu)
+ - Gabriellyan Catheline Sanger (cathelines)


### PR DESCRIPTION
[GCI2018] Added Gabriellyan Catheline Sanger as a contibutor on CONTRIBUTORS.md.
