### PR TITLE
Add GitHub link of Bassa on login page

### DIFF
--- a/ui/src/index.html
+++ b/ui/src/index.html
@@ -20,6 +20,18 @@
     <!-- css files will be automaticaly insert here -->
     <!-- endinject -->
     <!-- endbuild -->
+    <style>
+  .center {
+  			display: block;
+  			margin-left: auto;
+  			margin-right: auto;
+  			margin-top:-180px;
+  			padding-left: auto;
+  			padding-right: auto;
+  			padding-bottom: auto;
+  			padding-top:auto;
+		}
+	</style>
   </head>
   <body>
     <!--[if lt IE 10]>
@@ -28,8 +40,11 @@
         to improve your experience.</p>
     <![endif]-->
 
-    <div ui-view layout="row" layout-fill layout-align="center"></div>
+    <div ui-view layout="row" layout-fill layout-align="center">
+    	    
 
+    </div>
+<a href="https://github.com/scorelab/Bassa"><img src="https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png" class="center" width="50" height="50"alt="!sorry"></a>
     <!-- build:js(src) scripts/vendor.js -->
     <!-- bower:js -->
     <!-- run `gulp wiredep` to automaticaly populate bower script dependencies -->


### PR DESCRIPTION
fixes #511



## Description
Added GitHub logo which  will direct to the GitHub link of Bassa on the login page

## Related Issue
https://github.com/scorelab/Bassa/issues/511
## Motivation and Context
This change makes the user easy to access the GitHub link of Bassa from the login page itself.
## How Has This Been Tested?
I tested the changed code by running my localhost.
## Screenshots (In case of UI changes):
![Screenshot](https://i.ibb.co/TR5RVYw/Screenshot-from-2019-03-01-18-06-38.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
