### PR TITLE
Indentation error in the README.md file

### DIFF
--- a/ui/src/index.html
+++ b/ui/src/index.html
@@ -20,6 +20,18 @@
     <!-- css files will be automaticaly insert here -->
     <!-- endinject -->
     <!-- endbuild -->
+    <style>
+  .center {
+  			display: block;
+  			margin-left: auto;
+  			margin-right: auto;
+  			margin-top:-180px;
+  			padding-left: auto;
+  			padding-right: auto;
+  			padding-bottom: auto;
+  			padding-top:auto;
+		}
+	</style>
   </head>
   <body>
     <!--[if lt IE 10]>
@@ -28,8 +40,11 @@
         to improve your experience.</p>
     <![endif]-->
 
-    <div ui-view layout="row" layout-fill layout-align="center"></div>
+    <div ui-view layout="row" layout-fill layout-align="center">
+    	    
 
+    </div>
+<a href="https://github.com/scorelab/Bassa"><img src="https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png" class="center" width="50" height="50"alt="!sorry"></a>
     <!-- build:js(src) scripts/vendor.js -->
     <!-- bower:js -->
     <!-- run `gulp wiredep` to automaticaly populate bower script dependencies -->


### PR DESCRIPTION
fixes #185 

Cleared indentation error in the README.md file.
## Description
Commands given under Run UI Unit Tests were not properly indented. Fixed that issue by removing tab space behind the commands.

## Related Issue
#185 
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
This change makes the README.md file perfect without any indentation errors.

## How Has This Been Tested?

<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (In case of UI changes):
![screenshot from 2019-03-04 13-42-08](https://user-images.githubusercontent.com/43848929/53719669-c13b3980-3e84-11e9-9f37-d1618530ca76.png)





## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
