### PR TITLE
added feature of switching themes in login page, firefox-launcher for testing and displaying queued downloads

### DIFF
--- a/ui/karma.conf.js
+++ b/ui/karma.conf.js
@@ -7,15 +7,15 @@ module.exports = function(config) {
 
     frameworks: ['jasmine'],
 
-    browsers : ['Chrome', 'Firefox'],
+    browsers : ['Chrome','Firefox'],
 
     reporters: ['spec'],
 
     plugins : [
-        'karma-chrome-launcher',
-        'karma-firefox-launcher',
-        'karma-jasmine',
-        'karma-spec-reporter'
+      'karma-chrome-launcher',
+      'karma-firefox-launcher',
+      'karma-jasmine',
+      'karma-spec-reporter'
     ],
     files: [
       'bower_components/jquery/dist/jquery.js',

--- a/ui/karma.conf.js
+++ b/ui/karma.conf.js
@@ -7,7 +7,7 @@ module.exports = function(config) {
 
     frameworks: ['jasmine'],
 
-    browsers : ['Chrome','Firefox'],
+    browsers : ['Chrome', 'Firefox'],
 
     reporters: ['spec'],
 

--- a/ui/karma.conf.js
+++ b/ui/karma.conf.js
@@ -7,11 +7,11 @@ module.exports = function(config) {
 
     frameworks: ['jasmine'],
 
-    browsers : ['Chrome', 'Firefox'],
+    browsers: ['Chrome', 'Firefox'],
 
     reporters: ['spec'],
 
-    plugins : [
+    plugins: [
       'karma-chrome-launcher',
       'karma-firefox-launcher',
       'karma-jasmine',

--- a/ui/karma.conf.js
+++ b/ui/karma.conf.js
@@ -7,12 +7,13 @@ module.exports = function(config) {
 
     frameworks: ['jasmine'],
 
-    browsers : ['Chrome'],
+    browsers : ['Chrome', 'Firefox'],
 
     reporters: ['spec'],
 
     plugins : [
         'karma-chrome-launcher',
+        'karma-firefox-launcher',
         'karma-jasmine',
         'karma-spec-reporter'
     ],

--- a/ui/package.json
+++ b/ui/package.json
@@ -92,6 +92,7 @@
     "karma-chrome-launcher": "^2.0.0",
     "karma-cli": "~1.0.1",
     "karma-coverage-istanbul-reporter": "^1.2.1",
+    "karma-firefox-launcher": "^1.1.0",
     "karma-jasmine": "~0.3.1",
     "karma-jasmine-html-reporter": "^0.2.2",
     "karma-spec-reporter": "0.0.26",
@@ -113,6 +114,6 @@
   "scripts": {
     "init": "npm install",
     "install": "bower --allow-root install",
-    "test": "./node_modules/.bin/karma start --single-run --browsers Chrome"
+    "test": "./node_modules/.bin/karma start --single-run --browsers Chrome,Firefox"
   }
 }

--- a/ui/package.json
+++ b/ui/package.json
@@ -97,7 +97,7 @@
     "karma-jasmine-html-reporter": "^0.2.2",
     "karma-spec-reporter": "0.0.26",
     "main-bower-files": "~2.4.0",
-    "node-sass": "^4.5.0",
+    "node-sass": "^4.11.0",
     "postcss": "^5.1.2",
     "prettier": "^1.2.2",
     "protractor": "~1.4.0",

--- a/ui/src/app/admin/controllers/AdminCtrl.js
+++ b/ui/src/app/admin/controllers/AdminCtrl.js
@@ -1,4 +1,6 @@
 /* global document, sessionStorage */
+/*eslint no-plusplus: ["error", { "allowForLoopAfterthoughts": true }]*/
+
 (function(){
   'use strict';
   angular

--- a/ui/src/app/admin/controllers/AdminCtrl.js
+++ b/ui/src/app/admin/controllers/AdminCtrl.js
@@ -1,4 +1,4 @@
-/* global document */
+/* global document, sessionStorage */
 (function(){
   'use strict';
   angular
@@ -9,7 +9,7 @@
 
     $scope.signup_requests = [];
     $scope.usageChartData = [];
-    if(sessionStorage.getItem('isDarkThemeOn') === 'true') {
+    if (sessionStorage.getItem('isDarkThemeOn') === 'true') {
       $scope.addTheme = 'dark';
     }
     $scope.chartOptions = {
@@ -67,9 +67,9 @@
     this.getHeavyUsers = function() {
       AdminService.getHeavyUsers().then(function (response) {
         $scope.usageChartData = response.data;
-        if(sessionStorage.getItem('isDarkThemeOn') == 'true') {
+        if (sessionStorage.getItem('isDarkThemeOn') == 'true') {
           const rows = document.querySelectorAll('.row-entry');
-          for(let i=0;i<rows.length;i++) {
+          for (let i = 0; i < rows.length; i++) {
             rows[i].style.backgroundColor = '#303030';
           }
         }

--- a/ui/src/app/admin/controllers/AdminCtrl.js
+++ b/ui/src/app/admin/controllers/AdminCtrl.js
@@ -1,5 +1,5 @@
 /* global document, sessionStorage */
-/*eslint no-plusplus: ["error", { "allowForLoopAfterthoughts": true }]*/
+/* eslint no-plusplus: ["error", { "allowForLoopAfterthoughts": true }] */
 
 (function(){
   'use strict';

--- a/ui/src/app/admin/controllers/AdminCtrl.js
+++ b/ui/src/app/admin/controllers/AdminCtrl.js
@@ -1,3 +1,4 @@
+/* global document */
 (function(){
   'use strict';
   angular
@@ -8,7 +9,9 @@
 
     $scope.signup_requests = [];
     $scope.usageChartData = [];
-
+    if(sessionStorage.getItem('isDarkThemeOn') === 'true') {
+      $scope.addTheme = 'dark';
+    }
     $scope.chartOptions = {
         chart: {
             type: 'pieChart',
@@ -64,6 +67,12 @@
     this.getHeavyUsers = function() {
       AdminService.getHeavyUsers().then(function (response) {
         $scope.usageChartData = response.data;
+        if(sessionStorage.getItem('isDarkThemeOn') == 'true') {
+          const rows = document.querySelectorAll('.row-entry');
+          for(let i=0;i<rows.length;i++) {
+            rows[i].style.backgroundColor = '#303030';
+          }
+        }
       });
     }
 

--- a/ui/src/app/completed/controllers/TableCtrl.js
+++ b/ui/src/app/completed/controllers/TableCtrl.js
@@ -1,5 +1,5 @@
 /* global document, sessionStorage */
-/*eslint no-plusplus: ["error", { "allowForLoopAfterthoughts": true }]*/
+/* eslint no-plusplus: ["error", { "allowForLoopAfterthoughts": true }] */
 
 (function(){
   'use strict';
@@ -10,7 +10,7 @@
         if (scope.$last) {
           scope.$emit('LastRepeaterElement')
         }
-      }
+      };
     })
     .controller('TableCtrl', [ '$scope', '$mdToast', '$mdDialog','BassaUrl', 'ToastService', 'TableService', 'UtilityService', TableCtrl]);
 

--- a/ui/src/app/completed/controllers/TableCtrl.js
+++ b/ui/src/app/completed/controllers/TableCtrl.js
@@ -1,11 +1,11 @@
-/* global document */
+/* global document, sessionStorage */
 (function(){
   'use strict';
   angular
     .module('app')
     .directive('emitLastRepeaterElement', function() {
       return function(scope) {
-        if(scope.$last) {
+        if (scope.$last) {
           scope.$emit('LastRepeaterElement')
         }
       }
@@ -20,7 +20,7 @@
     $scope.checkedFileArray = [];
     $scope.shareLink = BassaUrl;
     $scope.isShowingCheckbox = false;
-    if(sessionStorage.getItem('isDarkThemeOn') === 'true') {
+    if (sessionStorage.getItem('isDarkThemeOn') === 'true') {
       $scope.addTheme = 'dark';
     }
     let progressDialog = {
@@ -138,11 +138,9 @@
     }
 
     $scope.$on('LastRepeaterElement', function() {
-      if(sessionStorage.getItem('isDarkThemeOn') == 'true')
-      {
+      if (sessionStorage.getItem('isDarkThemeOn') == 'true') {
         const rows = document.querySelectorAll('.complete-downloads-row-entry');
-        for(let i = 0;i < rows.length; i++)
-        {
+        for (let i = 0; i < rows.length; i++) {
           rows[i].style.background = '#303030';
         }
         const table = document.querySelector('.table');

--- a/ui/src/app/completed/controllers/TableCtrl.js
+++ b/ui/src/app/completed/controllers/TableCtrl.js
@@ -1,4 +1,6 @@
 /* global document, sessionStorage */
+/*eslint no-plusplus: ["error", { "allowForLoopAfterthoughts": true }]*/
+
 (function(){
   'use strict';
   angular

--- a/ui/src/app/completed/controllers/TableCtrl.js
+++ b/ui/src/app/completed/controllers/TableCtrl.js
@@ -1,7 +1,15 @@
+/* global document */
 (function(){
   'use strict';
   angular
     .module('app')
+    .directive('emitLastRepeaterElement', function() {
+      return function(scope) {
+        if(scope.$last) {
+          scope.$emit('LastRepeaterElement')
+        }
+      }
+    })
     .controller('TableCtrl', [ '$scope', '$mdToast', '$mdDialog','BassaUrl', 'ToastService', 'TableService', 'UtilityService', TableCtrl]);
 
   function TableCtrl($scope, $mdToast, $mdDialog, BassaUrl, ToastService, TableService, UtilityService) {
@@ -12,6 +20,9 @@
     $scope.checkedFileArray = [];
     $scope.shareLink = BassaUrl;
     $scope.isShowingCheckbox = false;
+    if(sessionStorage.getItem('isDarkThemeOn') === 'true') {
+      $scope.addTheme = 'dark';
+    }
     let progressDialog = {
       controller: DialogController,
       template: '<md-progress-linear md-mode="indeterminate"/>', // later change it to a template URL
@@ -125,6 +136,20 @@
         };
       }
     }
+
+    $scope.$on('LastRepeaterElement', function() {
+      if(sessionStorage.getItem('isDarkThemeOn') == 'true')
+      {
+        const rows = document.querySelectorAll('.complete-downloads-row-entry');
+        for(let i = 0;i < rows.length; i++)
+        {
+          rows[i].style.background = '#303030';
+        }
+        const table = document.querySelector('.table');
+        table.style.background = '#303030';
+      }
+    });
+
     $scope.deselectAll = function(){
       $scope.isShowingActions = false;
       angular.forEach($scope.downloads, function (item) {

--- a/ui/src/app/controllers/MainController.js
+++ b/ui/src/app/controllers/MainController.js
@@ -1,3 +1,4 @@
+/* global document */
 (function(){
   'use strict';
   angular
@@ -15,6 +16,13 @@
     $scope.toggleRightSidebar = toggleRightSidebar;
     $scope.logout = logout;
     $scope.username =  UserService.getUsername();
+    const x = document.getElementsByClassName('parent-container')[0];
+    x.id = 'temp_parent_id';
+    const isDarkThemeOn = sessionStorage.getItem('isDarkThemeOn');
+    if(isDarkThemeOn === 'true') {
+      document.getElementById('temp_parent_id').style.backgroundColor = '#404040';
+      $scope.sidenavTheme = 'dark';
+    }
 
     navService
       .loadAllItems()

--- a/ui/src/app/controllers/MainController.js
+++ b/ui/src/app/controllers/MainController.js
@@ -1,4 +1,4 @@
-/* global document */
+/* global document, sessionStorage */
 (function(){
   'use strict';
   angular
@@ -19,7 +19,7 @@
     const x = document.getElementsByClassName('parent-container')[0];
     x.id = 'temp_parent_id';
     const isDarkThemeOn = sessionStorage.getItem('isDarkThemeOn');
-    if(isDarkThemeOn === 'true') {
+    if (isDarkThemeOn === 'true') {
       document.getElementById('temp_parent_id').style.backgroundColor = '#404040';
       $scope.sidenavTheme = 'dark';
     }

--- a/ui/src/app/dashboard/controllers/DashCtrl.js
+++ b/ui/src/app/dashboard/controllers/DashCtrl.js
@@ -8,6 +8,7 @@
     var socket = io.connect(BassaUrl + '/progress');
     $scope.dlink = {link: ''};
     $scope.downloads = [];
+    $scope.queuedDownloads = [];
     $scope.username = UserService.getUsername();
 
     socket.on('connect', function(){
@@ -63,8 +64,7 @@
         $scope.downloads = _.reduce(data, function(queue, d) {
             if (d.status == 0) {
               let object = _.extend({}, d, {progress: 0});
-              queue.push(object)
-              return queue;
+              $scope.queuedDownloads.push(object)
             }
         }, []);
       }, function(error){
@@ -79,7 +79,7 @@
       if(deleteDownload){
         DashService.removeDownload(id).then(function(response){
           if(response.status === 200){
-            $scope.downloads.splice(index, 1);
+            $scope.queuedDownloads.splice(index, 1);
             ToastService.showToast("Download removed");
           }else{
             ToastService.showToast("Download could not be removed. Please try again!");

--- a/ui/src/app/dashboard/controllers/DashCtrl.js
+++ b/ui/src/app/dashboard/controllers/DashCtrl.js
@@ -1,4 +1,6 @@
 /* global document, sessionStorage */
+/*eslint no-plusplus: ["error", { "allowForLoopAfterthoughts": true }]*/
+
 (function(){
   'use strict';
   angular

--- a/ui/src/app/dashboard/controllers/DashCtrl.js
+++ b/ui/src/app/dashboard/controllers/DashCtrl.js
@@ -1,5 +1,5 @@
 /* global document, sessionStorage */
-/*eslint no-plusplus: ["error", { "allowForLoopAfterthoughts": true }]*/
+/* eslint no-plusplus: ["error", { "allowForLoopAfterthoughts": true }] */
 
 (function(){
   'use strict';

--- a/ui/src/app/dashboard/controllers/DashCtrl.js
+++ b/ui/src/app/dashboard/controllers/DashCtrl.js
@@ -1,7 +1,15 @@
+/* global document */
 (function(){
   'use strict';
   angular
     .module('app')
+    .directive('emitLastRepeaterElement', function() {
+      return function(scope) {
+        if(scope.$last) {
+          scope.$emit('LastRepeaterElement')
+        }
+      };
+    })
     .controller('DashCtrl', [ '$scope','$window','ToastService', 'DashService', 'UserService', 'BassaUrl', DashCtrl]);
 
   function DashCtrl($scope, $window , ToastService, DashService, UserService, BassaUrl) {
@@ -11,6 +19,9 @@
     $scope.queuedDownloads = [];
     $scope.username = UserService.getUsername();
 
+    if(sessionStorage.getItem('isDarkThemeOn') === 'true') {
+      $scope.addTheme = 'dark';
+    }
     socket.on('connect', function(){
       socket.emit('join', {room: $scope.username});
     });
@@ -34,6 +45,17 @@
         return false;
         }
     }
+
+    $scope.$on('LastRepeaterElement', function() {
+      if(sessionStorage.getItem('isDarkThemeOn') == 'true')
+      {
+        const rows = document.querySelectorAll('.queued-download-row-entry');
+        for(let i = 0;i < rows.length; i++)
+        {
+          rows[i].style.background = '#303030';
+        }
+      }
+    })
 
     $scope.addLink = function() {
       if ($scope.dlink.link === '' || $scope.dlink.link === undefined || !linkvalidator($scope.dlink.link)) {

--- a/ui/src/app/login/controllers/LoginCtrl.js
+++ b/ui/src/app/login/controllers/LoginCtrl.js
@@ -7,6 +7,10 @@
 
   function LoginCtrl($scope, $state, UserService) {
     $scope.user = {};
+    sessionStorage.setItem('isDarkThemeOn',false);
+    $scope.data = {
+      cb1: sessionStorage.getItem('isDarkThemeOn')
+    }
     $scope.login = function(){
       $scope.incorrectCredentials = false;
       $scope.unApproved = false;
@@ -26,12 +30,14 @@
     };
 
     $scope.onChange = function toggleTheme(cbState) {
-      const x = document.getElementsByClassName('parent-container')[0];
-      x.id = 'temp_id';
+      const login_class = document.getElementsByClassName('login-class')[0];
+      login_class.id = 'temp_id';
       if (cbState === true) {
-        document.getElementById('temp_id').style.backgroundColor = '#19223c';
+        document.getElementById('temp_id').style.backgroundColor = '#404040';
+        sessionStorage.setItem('isDarkThemeOn', true);
       } else {
         document.getElementById('temp_id').style.backgroundColor = '#fff';
+        sessionStorage.setItem('isDarkThemeOn', false);
       }
     };
 

--- a/ui/src/app/login/controllers/LoginCtrl.js
+++ b/ui/src/app/login/controllers/LoginCtrl.js
@@ -1,3 +1,4 @@
+/* global document */
 (function(){
   'use strict';
   angular
@@ -25,12 +26,11 @@
     };
 
     $scope.toggle = function toggleTheme() {
-      const x = document.getElementsByClassName('login-container')[0];  /* trying to get login page parent node */
+      const x = document.getElementsByClassName('login-container')[0]; /* trying to get login page parent node */
       x.id = 'temp_id';
       if (document.getElementById('temp_id').style.backgroundColor === 'rgb(25, 34, 60)') { /* checking if present mode is dark */
         document.getElementById('temp_id').style.backgroundColor = '#fff'; /* If it is true, then change it to light theme */
-      }
-      else { document.getElementById('temp_id').style.backgroundColor = '#19223c'; }
+      } else { document.getElementById('temp_id').style.backgroundColor = '#19223c'; }
     };
 
     UserService.cleanUpStorage();

--- a/ui/src/app/login/controllers/LoginCtrl.js
+++ b/ui/src/app/login/controllers/LoginCtrl.js
@@ -1,4 +1,4 @@
-/* global document */
+/* global document, sessionStorage */
 (function(){
   'use strict';
   angular
@@ -7,10 +7,10 @@
 
   function LoginCtrl($scope, $state, UserService) {
     $scope.user = {};
-    sessionStorage.setItem('isDarkThemeOn',false);
+    sessionStorage.setItem('isDarkThemeOn', false);
     $scope.data = {
       cb1: sessionStorage.getItem('isDarkThemeOn')
-    }
+    };
     $scope.login = function(){
       $scope.incorrectCredentials = false;
       $scope.unApproved = false;
@@ -30,13 +30,22 @@
     };
 
     $scope.onChange = function toggleTheme(cbState) {
-      const login_class = document.getElementsByClassName('login-class')[0];
-      login_class.id = 'temp_id';
+      const loginClass = document.getElementsByClassName('login-class')[0];
+      loginClass.id = 'temp_id';
+      const inputClass = document.querySelectorAll('.login-input');
       if (cbState === true) {
         document.getElementById('temp_id').style.backgroundColor = '#404040';
+        document.getElementById('temp_id').style.color = '#fff';
+        for (let i = inputClass.length - 1; i >= 0; i--) {
+          inputClass[i].style.color = '#fff';
+        }
         sessionStorage.setItem('isDarkThemeOn', true);
       } else {
         document.getElementById('temp_id').style.backgroundColor = '#fff';
+        document.getElementById('temp_id').style.color = '#9e9e9e';
+        for (let i = inputClass.length - 1; i >= 0; i--) {
+          inputClass[i].style.color = '#000';
+        }
         sessionStorage.setItem('isDarkThemeOn', false);
       }
     };

--- a/ui/src/app/login/controllers/LoginCtrl.js
+++ b/ui/src/app/login/controllers/LoginCtrl.js
@@ -25,9 +25,11 @@
     };
 
     $scope.toggle = function toggleTheme() {
-      const x = document.getElementsByClassName('login-container')[0];
+      const x = document.getElementsByClassName('login-container')[0];  /* trying to get login page parent node */
       x.id = 'temp_id';
-      if (document.getElementById('temp_id').style.backgroundColor === 'rgb(25, 34, 60)') { document.getElementById('temp_id').style.backgroundColor = '#fff'; }
+      if (document.getElementById('temp_id').style.backgroundColor === 'rgb(25, 34, 60)') { /* checking if present mode is dark */
+        document.getElementById('temp_id').style.backgroundColor = '#fff'; /* If it is true, then change it to light theme */
+      }
       else { document.getElementById('temp_id').style.backgroundColor = '#19223c'; }
     };
 

--- a/ui/src/app/login/controllers/LoginCtrl.js
+++ b/ui/src/app/login/controllers/LoginCtrl.js
@@ -1,4 +1,6 @@
 /* global document, sessionStorage */
+/*eslint no-plusplus: ["error", { "allowForLoopAfterthoughts": true }]*/
+
 (function(){
   'use strict';
   angular
@@ -36,14 +38,14 @@
       if (cbState === true) {
         document.getElementById('temp_id').style.backgroundColor = '#404040';
         document.getElementById('temp_id').style.color = '#fff';
-        for (let i =  0; i < inputClass.length; i++) {
+        for (let i = 0; i < inputClass.length; i++) {
           inputClass[i].style.color = '#fff';
         }
         sessionStorage.setItem('isDarkThemeOn', true);
       } else {
         document.getElementById('temp_id').style.backgroundColor = '#fff';
         document.getElementById('temp_id').style.color = '#9e9e9e';
-        for (let i =  0; i < inputClass.length; i++) {
+        for (let i = 0; i < inputClass.length; i++) {
           inputClass[i].style.color = '#000';
         }
         sessionStorage.setItem('isDarkThemeOn', false);

--- a/ui/src/app/login/controllers/LoginCtrl.js
+++ b/ui/src/app/login/controllers/LoginCtrl.js
@@ -25,13 +25,18 @@
       $state.go('signup');
     };
 
-    $scope.toggle = function toggleTheme() {
-      const x = document.getElementsByClassName('login-container')[0]; /* trying to get login page parent node */
-      x.id = 'temp_id';
-      if (document.getElementById('temp_id').style.backgroundColor === 'rgb(25, 34, 60)') { /* checking if present mode is dark */
-        document.getElementById('temp_id').style.backgroundColor = '#fff'; /* If it is true, then change it to light theme */
-      } else { document.getElementById('temp_id').style.backgroundColor = '#19223c'; }
-    };
+    $scope.onChange = function(cbState) {
+      //console.log(cbState)
+      let x = document.getElementsByClassName("parent-container")[0];
+      x.id = "temp_id";
+      if(cbState === true) {
+        //console.log('true value')
+        document.getElementById("temp_id").style.backgroundColor="#19223c";
+      } else {
+        //console.log('false value')
+        document.getElementById("temp_id").style.backgroundColor="#fff";
+      }
+    }
 
     UserService.cleanUpStorage();
   }

--- a/ui/src/app/login/controllers/LoginCtrl.js
+++ b/ui/src/app/login/controllers/LoginCtrl.js
@@ -9,7 +9,7 @@
     $scope.user = {};
     sessionStorage.setItem('isDarkThemeOn', false);
     $scope.data = {
-      cb1: sessionStorage.getItem('isDarkThemeOn')
+      cb1: sessionStorage.getItem('isDarkThemeOn'),
     };
     $scope.login = function(){
       $scope.incorrectCredentials = false;
@@ -36,14 +36,14 @@
       if (cbState === true) {
         document.getElementById('temp_id').style.backgroundColor = '#404040';
         document.getElementById('temp_id').style.color = '#fff';
-        for (let i = inputClass.length - 1; i >= 0; i--) {
+        for (let i =  0; i < inputClass.length; i++) {
           inputClass[i].style.color = '#fff';
         }
         sessionStorage.setItem('isDarkThemeOn', true);
       } else {
         document.getElementById('temp_id').style.backgroundColor = '#fff';
         document.getElementById('temp_id').style.color = '#9e9e9e';
-        for (let i = inputClass.length - 1; i >= 0; i--) {
+        for (let i =  0; i < inputClass.length; i++) {
           inputClass[i].style.color = '#000';
         }
         sessionStorage.setItem('isDarkThemeOn', false);

--- a/ui/src/app/login/controllers/LoginCtrl.js
+++ b/ui/src/app/login/controllers/LoginCtrl.js
@@ -1,5 +1,5 @@
 /* global document, sessionStorage */
-/*eslint no-plusplus: ["error", { "allowForLoopAfterthoughts": true }]*/
+/* eslint no-plusplus: ["error", { "allowForLoopAfterthoughts": true }] */
 
 (function(){
   'use strict';

--- a/ui/src/app/login/controllers/LoginCtrl.js
+++ b/ui/src/app/login/controllers/LoginCtrl.js
@@ -25,18 +25,15 @@
       $state.go('signup');
     };
 
-    $scope.onChange = function(cbState) {
-      //console.log(cbState)
-      let x = document.getElementsByClassName("parent-container")[0];
-      x.id = "temp_id";
-      if(cbState === true) {
-        //console.log('true value')
-        document.getElementById("temp_id").style.backgroundColor="#19223c";
+    $scope.onChange = function toggleTheme (cbState) {
+      const x = document.getElementsByClassName('parent-container')[0];
+      x.id = 'temp_id';
+      if (cbState === true) {
+        document.getElementById('temp_id').style.backgroundColor = '#19223c';
       } else {
-        //console.log('false value')
-        document.getElementById("temp_id").style.backgroundColor="#fff";
+        document.getElementById('temp_id').style.backgroundColor = '#fff';
       }
-    }
+    };
 
     UserService.cleanUpStorage();
   }

--- a/ui/src/app/login/controllers/LoginCtrl.js
+++ b/ui/src/app/login/controllers/LoginCtrl.js
@@ -24,19 +24,12 @@
       $state.go('signup');
     };
 
-    $scope.toggle = function () {
-      let x = document.getElementsByClassName("login-container")[0];
-      x.id = "temp_id";
-      let y = document.getElementById("temp_id").style.backgroundColor;
-      if(document.getElementById("temp_id").style.backgroundColor === "rgb(25, 34, 60)")
-      {
-        document.getElementById("temp_id").style.backgroundColor="#fff";
-      }
-      else
-      {
-        document.getElementById("temp_id").style.backgroundColor="#19223c";
-      }
-    }
+    $scope.toggle = function toggleTheme() {
+      const x = document.getElementsByClassName('login-container')[0];
+      x.id = 'temp_id';
+      if (document.getElementById('temp_id').style.backgroundColor === 'rgb(25, 34, 60)') { document.getElementById('temp_id').style.backgroundColor = '#fff'; }
+      else { document.getElementById('temp_id').style.backgroundColor = '#19223c'; }
+    };
 
     UserService.cleanUpStorage();
   }

--- a/ui/src/app/login/controllers/LoginCtrl.js
+++ b/ui/src/app/login/controllers/LoginCtrl.js
@@ -25,7 +25,7 @@
       $state.go('signup');
     };
 
-    $scope.onChange = function toggleTheme (cbState) {
+    $scope.onChange = function toggleTheme(cbState) {
       const x = document.getElementsByClassName('parent-container')[0];
       x.id = 'temp_id';
       if (cbState === true) {

--- a/ui/src/app/login/controllers/LoginCtrl.js
+++ b/ui/src/app/login/controllers/LoginCtrl.js
@@ -24,6 +24,20 @@
       $state.go('signup');
     };
 
+    $scope.toggle = function () {
+      let x = document.getElementsByClassName("login-container")[0];
+      x.id = "temp_id";
+      let y = document.getElementById("temp_id").style.backgroundColor;
+      if(document.getElementById("temp_id").style.backgroundColor === "rgb(25, 34, 60)")
+      {
+        document.getElementById("temp_id").style.backgroundColor="#fff";
+      }
+      else
+      {
+        document.getElementById("temp_id").style.backgroundColor="#19223c";
+      }
+    }
+
     UserService.cleanUpStorage();
   }
 

--- a/ui/src/app/stylesheets/_custom.scss
+++ b/ui/src/app/stylesheets/_custom.scss
@@ -22,9 +22,29 @@ body {
   padding-right: 50px;
 }
 
+.login-class {
+  margin-top:0px;
+  display: inline-block;
+  align-items: center;
+  background: #fff;
+}
+
 .parent-container {
   background: #fff;
 }
+
+.row-entry {
+  background: #fff;
+}
+
+.complete-downloads-row-entry {
+  background-color: #fff;
+}
+
+.queued-download-row-entry {
+  background-color: #fff;  
+}
+
 .toolbar-button {
   min-width: 20px;
 }

--- a/ui/src/app/stylesheets/_custom.scss
+++ b/ui/src/app/stylesheets/_custom.scss
@@ -17,6 +17,14 @@ body {
   color: $text-color;
 }
 
+.dark-theme-switch {
+  float: right;
+  padding-right: 50px;
+}
+
+.parent-container {
+  background: #fff;
+}
 .toolbar-button {
   min-width: 20px;
 }
@@ -192,7 +200,8 @@ md-backdrop.md-sidenav-backdrop {
 }
 
 .login-container{
-  background: #fff;
+  background: transparent;
+  margin-top: 100px;
 }
 
 .label-styles{

--- a/ui/src/app/stylesheets/_custom.scss
+++ b/ui/src/app/stylesheets/_custom.scss
@@ -191,12 +191,24 @@ md-backdrop.md-sidenav-backdrop {
   cursor: pointer;
 }
 
+.login-container{
+  background: #fff;
+}
+
+.label-styles{
+  color: #757575;
+}
+
 .input-container{
   margin:1px;
 }
 
 .login-content{
   width: 23%;
+}
+
+.toggle-button{
+  background:#ff6600;
 }
 
 .login-button{

--- a/ui/src/app/stylesheets/_custom.scss
+++ b/ui/src/app/stylesheets/_custom.scss
@@ -29,6 +29,10 @@ body {
   background: #fff;
 }
 
+.login-input {
+  color: #000;
+}
+
 .parent-container {
   background: #fff;
 }

--- a/ui/src/app/views/admin.html
+++ b/ui/src/app/views/admin.html
@@ -1,6 +1,6 @@
 <div layout-gt-md="column" layout-align="center">
 
-  <md-content class="md-padding" layout="row" layout-sm="column">
+  <md-content class="md-padding" layout="row" layout-sm="column" md-theme="{{addTheme}}">
       <md-subheader class="md-primary">Start/Kill all downloads</md-subheader>
 
       <br>
@@ -14,12 +14,12 @@
   </md-content>
 
   <div ng-if="data?.length > 0">
-   <md-content class="block md-padding table-responsive-vertical" >
+   <md-content class="block md-padding table-responsive-vertical" md-theme="{{addTheme}}">
       <md-subheader class="md-primary">Signup requests</md-subheader>
 
       <table id="table" class="table table-hover table-bordered signup-requests-table">
           <tbody>
-          <tr ng-repeat="data in signup_requests">
+          <tr class="row-entry" ng-repeat="data in signup_requests">
               <td data-title="ID">{{$index + 1}}</td>
               <td data-title="Name">{{data.user_name}}</td>
               <td data-title="Email">{{data.email}}</td>
@@ -36,12 +36,12 @@
   </div>
 
   <div ng-if="!data.length == true">
-    <md-content class="no-data-content" >
+    <md-content class="no-data-content" md-theme="{{addTheme}}">
       <h4>There are no pending signup requests!</h4>
     </md-content>
   </div>
 
-  <md-content class="block md-padding table-responsive-vertical" >
+  <md-content class="block md-padding table-responsive-vertical" md-theme="{{addTheme}}">
     <md-subheader class="md-primary">Usage of top heaviest users</md-subheader>
     <nvd3 options="chartOptions" data="usageChartData"></nvd3>
   </md-content>

--- a/ui/src/app/views/dashboard.html
+++ b/ui/src/app/views/dashboard.html
@@ -1,6 +1,6 @@
 <div layout-gt-md="column" layout-align="center">
 
-  <md-content class="add-download-box" >
+  <md-content class="add-download-box" md-theme="{{addTheme}}">
     <md-input-container flex class="downlod-input-box" ng-keyup="addDownload($event)">
         <label>Add download</label>
         <input ng-model="dlink.link" name="taskText" type="text">
@@ -11,11 +11,11 @@
   </md-content>
 
   <div ng-if="queuedDownloads.length > 0">
-    <md-content class="downloads md-padding table-responsive-vertical" >
-      <h4 class="panel-widget-title"> On going downloads</h4>
+    <md-content class="downloads md-padding table-responsive-vertical" md-theme="{{addTheme}}">
+      <h4 class="panel-widget-title"> On going/Queued downloads</h4>
       <table id="table" class="table table-hover table-bordered">
           <thead>
-          <tr ng-repeat="data in queuedDownloads">
+          <tr ng-repeat="data in queuedDownloads" class="queued-download-row-entry" emit-last-repeater-element>
               <td id="vertalign" data-title="ID">{{$index + 1}}</td>
               <td id="vertalign" data-title="Issue">{{data.download_name}}</td>
               <td id="vertalign" data-title="Progress">
@@ -34,8 +34,8 @@
     </md-content>
   </div>
 
-  <div ng-if="data.length == 0">
-    <md-content class="no-data-content" >
+  <div ng-if="queuedDownloads.length == 0">
+    <md-content class="no-data-content"  md-theme="{{addTheme}}">
       <h4>There are no queued downloads, please add some!</h4>
     </md-content>
   </div>

--- a/ui/src/app/views/dashboard.html
+++ b/ui/src/app/views/dashboard.html
@@ -10,12 +10,12 @@
     </md-button>
   </md-content>
 
-  <div ng-if="data?.length > 0">
+  <div ng-if="queuedDownloads.length > 0">
     <md-content class="downloads md-padding table-responsive-vertical" >
-      <h4 class="panel-widget-tittle"> On going downloads</h4>
+      <h4 class="panel-widget-title"> On going downloads</h4>
       <table id="table" class="table table-hover table-bordered">
           <thead>
-          <tr ng-repeat="data in downloads track by $index">
+          <tr ng-repeat="data in queuedDownloads">
               <td id="vertalign" data-title="ID">{{$index + 1}}</td>
               <td id="vertalign" data-title="Issue">{{data.download_name}}</td>
               <td id="vertalign" data-title="Progress">
@@ -34,7 +34,7 @@
     </md-content>
   </div>
 
-  <div ng-if="!data.length == true">
+  <div ng-if="data.length == 0">
     <md-content class="no-data-content" >
       <h4>There are no queued downloads, please add some!</h4>
     </md-content>

--- a/ui/src/app/views/dashboard.html
+++ b/ui/src/app/views/dashboard.html
@@ -15,7 +15,7 @@
       <h4 class="panel-widget-title"> On going/Queued downloads</h4>
       <table id="table" class="table table-hover table-bordered">
           <thead>
-          <tr ng-repeat="data in queuedDownloads" class="queued-download-row-entry" emit-last-repeater-element>
+          <tr ng-repeat="data in queuedDownloads track by $index" class="queued-download-row-entry" emit-last-repeater-element>
               <td id="vertalign" data-title="ID">{{$index + 1}}</td>
               <td id="vertalign" data-title="Issue">{{data.download_name}}</td>
               <td id="vertalign" data-title="Progress">

--- a/ui/src/app/views/login.html
+++ b/ui/src/app/views/login.html
@@ -1,4 +1,4 @@
-<div class="parent-container">
+<div class="login-class">
         <div class="dark-theme-switch">
             <md-switch ng-model="data.cb1" aria-label="Switch" float="right" ng-Change="onChange(data.cb1)">
                 Dark Theme

--- a/ui/src/app/views/login.html
+++ b/ui/src/app/views/login.html
@@ -9,11 +9,11 @@
         <div layout="column" class="login-content">
             <md-input-container class="input-container">
                 <label class="label-styles">User name</label>
-                <input type="text" ng-model="user.user_name" />
+                <input class="login-input" type="text" ng-model="user.user_name" />
             </md-input-container>
             <md-input-container class="input-container">
                 <label class="label-styles">Password</label>
-                <input type="password" ng-model="user.password" ng-enter="login()" />
+                <input class="login-input" type="password" ng-model="user.password" ng-enter="login()" />
             </md-input-container>
             <md-button class="md-raised md-primary login-button" ng-click="login()">Login</md-button>
             <div layout="row">

--- a/ui/src/app/views/login.html
+++ b/ui/src/app/views/login.html
@@ -1,28 +1,32 @@
-<div class="login-container" layout="column" layout-align="center center">
-    <img class="logo" ng-src="assets/images/logo.png">
-    <div layout="column" class="login-content">
-        <md-input-container class="input-container">
-            <label class="label-styles">User name</label>
-            <input type="text" ng-model="user.user_name" />
-        </md-input-container>
-        <md-input-container class="input-container">
-            <label class="label-styles">Password</label>
-            <input type="password" ng-model="user.password" ng-enter="login()" />
-        </md-input-container>
-        <md-button class="md-raised md-primary login-button" ng-click="login()">Login</md-button>
-        <div layout="row">
-            <p>Don't have an account?</p>
-            <a class="" id="signup-button" ng-click="signup()">Signup</a>
+<div class="parent-container">
+        <div class="dark-theme-switch">
+            <md-switch ng-model="data.cb1" aria-label="Switch" float="right" ng-Change="onChange(data.cb1)">
+                Dark Theme
+            </md-switch>
         </div>
-        <md-button class="md-accent md-raised toggle-button" ng-click="toggle()">
-            <div class="label">toggle theme</div>
-        </md-button>
-        <br>
-    </div>
-    <div class="alert" ng-if="incorrectCredentials">
-        <span class="closebtn msg" onclick="this.parentElement.style.display='none';">&times;</span> Incorrect Credentials
-    </div>
-    <div class="alert" ng-if="unApproved">
-        <span class="closebtn msg" onclick="this.parentElement.style.display='none';">&times;</span> Please confirm your account
+    <div class="login-container" layout="column" layout-align="center center">
+        <img class="logo" ng-src="assets/images/logo.png">
+        <div layout="column" class="login-content">
+            <md-input-container class="input-container">
+                <label class="label-styles">User name</label>
+                <input type="text" ng-model="user.user_name" />
+            </md-input-container>
+            <md-input-container class="input-container">
+                <label class="label-styles">Password</label>
+                <input type="password" ng-model="user.password" ng-enter="login()" />
+            </md-input-container>
+            <md-button class="md-raised md-primary login-button" ng-click="login()">Login</md-button>
+            <div layout="row">
+                <p>Don't have an account?</p>
+                <a class="" id="signup-button" ng-click="signup()">Signup</a>
+            </div>
+            <br>
+        </div>
+        <div class="alert" ng-if="incorrectCredentials">
+            <span class="closebtn msg" onclick="this.parentElement.style.display='none';">&times;</span> Incorrect Credentials
+        </div>
+        <div class="alert" ng-if="unApproved">
+            <span class="closebtn msg" onclick="this.parentElement.style.display='none';">&times;</span> Please confirm your account
+        </div>
     </div>
 </div>

--- a/ui/src/app/views/login.html
+++ b/ui/src/app/views/login.html
@@ -1,12 +1,12 @@
-<div layout="column" layout-align="center center">
+<div class="login-container" layout="column" layout-align="center center">
     <img class="logo" ng-src="assets/images/logo.png">
     <div layout="column" class="login-content">
         <md-input-container class="input-container">
-            <label>User name</label>
+            <label class="label-styles">User name</label>
             <input type="text" ng-model="user.user_name" />
         </md-input-container>
         <md-input-container class="input-container">
-            <label>Password</label>
+            <label class="label-styles">Password</label>
             <input type="password" ng-model="user.password" ng-enter="login()" />
         </md-input-container>
         <md-button class="md-raised md-primary login-button" ng-click="login()">Login</md-button>
@@ -14,6 +14,9 @@
             <p>Don't have an account?</p>
             <a class="" id="signup-button" ng-click="signup()">Signup</a>
         </div>
+        <md-button class="md-accent md-raised toggle-button" ng-click="toggle()">
+            <div class="label">toggle theme</div>
+        </md-button>
         <br>
     </div>
     <div class="alert" ng-if="incorrectCredentials">

--- a/ui/src/app/views/main.html
+++ b/ui/src/app/views/main.html
@@ -1,5 +1,5 @@
 <md-sidenav md-is-locked-open="$mdMedia('gt-sm')" md-component-id="left"
-            class="md-whiteframe-z2 md-sidenav-left">
+            class="md-whiteframe-z2 md-sidenav-left" md-theme="{{sidenavTheme}}">
   <md-toolbar md-theme="custom" class="md-hue-1 md-whiteframe-z2">
     <md-button layout="row" layout-align="center center" class="md-toolbar-tools md-warn" onClick="parent.open('https://github.com/scorelab/Bassa')">
     <img class="" src="assets/images/bassa.png">
@@ -37,7 +37,7 @@
         </section>
     </md-toolbar>
 
-    <md-content flex class="md-padding page-content">
+    <md-content flex class="md-padding page-content parent-container">
         <div ui-view></div>
     </md-content>
 </div>

--- a/ui/src/app/views/table.html
+++ b/ui/src/app/views/table.html
@@ -5,33 +5,35 @@
         <md-button ng-show="isShowingCheckbox" ng-click="deselectAll()"><i class="material-icons ng-scope">check_circle_outline</i></md-button>
         <md-button ng-show="isShowingCheckbox" ng-click="selectAll()"><i class="material-icons ng-scope">check_circle</i></md-button>
     </div>
-    <table id="table" class="table table-hover table-bordered" ng-show="!isGridVisible">
-        <thead>
-        <tr>
-            <th>#</th>
-            <th>User</th>
-            <th>Download name</th>
-            <th>Size</th>
-            <th>Completed time</th>
-            <th></th>
-        </tr>
-        </thead>
-        <tbody>
-        <tr ng-repeat="data in downloads" ng-click="onFileItemClick()">
-            <td data-title="ID">{{$index + 1}}</td>
-            <td data-title="User">{{data.user_name}}</td>
-            <td data-title="Issue">{{data.download_name}}</td>
-            <td data-title="Progress">{{data.size}}</td>
-            <td data-title="Completed time" am-time-ago="data.completed_time|amFromUnix"></td>
-            <td><button ng-click="compressFiles([data.gid])">Download</button></td>
-            <td><md-checkbox ng-show="isShowingCheckbox" ng-model="data.checked" ng-change="selectThisItem(data)"></md-checkbox></td>
-        </tr>
-        </tbody>
-    </table>
+    <md-content md-theme="{{addTheme}}">
+        <table id="table" class="table table-hover table-bordered" ng-show="!isGridVisible">
+            <thead>
+            <tr class="complete-downloads-row-entry">
+                <th>#</th>
+                <th>User</th>
+                <th>Download name</th>
+                <th>Size</th>
+                <th>Completed time</th>
+                <th></th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr class="complete-downloads-row-entry" ng-repeat="data in downloads" ng-click="onFileItemClick()" emit-last-repeater-element>
+                <td data-title="ID">{{$index + 1}}</td>
+                <td data-title="User">{{data.user_name}}</td>
+                <td data-title="Issue">{{data.download_name}}</td>
+                <td data-title="Progress">{{data.size}}</td>
+                <td data-title="Completed time" am-time-ago="data.completed_time|amFromUnix"></td>
+                <td><button ng-click="compressFiles([data.gid])">Download</button></td>
+                <td><md-checkbox ng-show="isShowingCheckbox" ng-model="data.checked" ng-change="selectThisItem(data)"></md-checkbox></td>
+            </tr>
+            </tbody>
+        </table>
+    </md-content>
 </div>
 
 <div ng-if="!data.length == true">
-  <md-content class="no-data-content" >
+  <md-content class="no-data-content" md-theme="{{addTheme}}">
     <h4>There are no completed downloads yet!</h4>
   </md-content>
 </div>


### PR DESCRIPTION
Added option for switching to both light or dark theme on Login page.

## Description
On the login page, user can switch either to Light theme (original theme) or can choose dark theme to reduce strain on his/her eyes.

## Related Issue
Fixes: #733 and #739

## Screenshots (In case of UI changes):
![Screenshot (17)](https://user-images.githubusercontent.com/28647524/55188017-5d283e80-51c0-11e9-91ab-55ef40c882a8.png)
When in Light theme mode

![Screenshot (18)](https://user-images.githubusercontent.com/28647524/55188042-6f09e180-51c0-11e9-896f-60e1e0c70ee1.png)
In Dark theme mode

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.

