### PR TITLE
Fixing create-schema.sh file

### DIFF
--- a/.docker/volumes/mysql/create-schema.sh
+++ b/.docker/volumes/mysql/create-schema.sh
@@ -4,7 +4,8 @@ SCHEMA_DIR=/tmp/schema
 
 mysql_exec=( mysql -uroot -p${MYSQL_ROOT_PASSWORD} )
 
-if [[-z "$BASSA_DB_NAME" ]]
+if [[ -z "$BASSA_DB_NAME" ]]
+then
     echo "BASSA_DB_NAME is not defined."
     exit 1
 fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,7 @@ services:
       MYSQL_DATABASE: ${BASSA_DB_NAME}
       MYSQL_USER: ${BASSA_DB_USERNAME}
       MYSQL_PASSWORD: ${BASSA_DB_PASSWORD}
+      BASSA_DB_NAME: ${BASSA_DB_NAME}
 
 volumes:
   data-volume:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Resolved syntax errors in create-schema.sh script
* This script required `BASSA_DB_NAME` env variable which is now passed through docker-compose file.
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#743 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Due to semantic and syntax errors in create-schema.sh file it fails to push the schema to the database.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
