### PR TITLE
Nginx as reverse proxy server for Bassa web in docker environment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,5 +35,13 @@ services:
       MYSQL_USER: ${BASSA_DB_USERNAME}
       MYSQL_PASSWORD: ${BASSA_DB_PASSWORD}
 
+  proxy:
+    build: ui/proxy/
+    container_name: proxy
+    ports:
+      - 80:80
+    links:
+      - web
+
 volumes:
   data-volume:

--- a/ui/proxy/dockerfile
+++ b/ui/proxy/dockerfile
@@ -1,0 +1,3 @@
+FROM nginx:alpine
+RUN rm /etc/nginx/conf.d/*
+COPY proxy.conf /etc/nginx/conf.d

--- a/ui/proxy/proxy.conf
+++ b/ui/proxy/proxy.conf
@@ -1,0 +1,8 @@
+server {
+    listen 80;
+
+    location / {
+        # specific to docker environment
+        proxy_pass http://web:3000;
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
We shall use nginx as a reverse proxy server to direct traffic to `localhost:3000` when they use `localhost`
Here nginx is used as a separate service.
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#745 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
`localhost` with no specific ports will be a easily accessible url to Bassa web component rather using the usual `localhost:3000`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
