### PR TITLE
 Move aria server value to config 

### DIFF
--- a/components/core/routes/Download.py
+++ b/components/core/routes/Download.py
@@ -9,6 +9,7 @@ from utils.app_constants import SERVER_SECRET_KEY
 from utils.token_utils import token_validator
 from initializer import socketio
 
+conf = get_conf_reader("dl.conf")
 
 def start():
 	try:
@@ -33,7 +34,7 @@ def kill():
 			p.join()
 			jsonreq = json.dumps({'jsonrpc': '2.0', 'id': 'qwer', 'method': 'aria2.pauseAll'})
 			jsonreq = jsonreq.encode('ascii')
-			c = urllib.request.urlopen('http://localhost:6800/jsonrpc', jsonreq)
+			c = urllib.request.urlopen(conf['aria_server'], jsonreq)
 			if verbose:
 				print(c)
 		if not p.is_alive():


### PR DESCRIPTION
This PR will make download.py to read aria2 server by a dl.conf. This is crucial for having separate aria2 containers.

## Related Issue
#407 
#747 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
