### PR TITLE
adding variable replicas in k8s script files

### DIFF
--- a/scripts/kubernetes/bassa-api.yaml
+++ b/scripts/kubernetes/bassa-api.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     run: bassa-api
 spec:
+  replicas: 2
   selector:
     matchLabels:
       run: bassa-api

--- a/scripts/kubernetes/bassa-ui.yaml
+++ b/scripts/kubernetes/bassa-ui.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     run: bassa-ui
 spec:
+  replicas: 1
   selector:
     matchLabels:
       run: bassa-ui


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Adding a variable for no. of replicas in k8s scripts

## Description
<!--- Describe your changes in detail -->
Currently k8s scripts of Bassa don't have variable `replicas` , so this variable is added and have given values, 
for `bassa-api.yaml` : `replicas: 2`
  &  `bassa-ui.yaml` : `replicas: 1`

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#751 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This will help to decide no. of clusters from k8s environment running for that particular service

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
