### PR TITLE
Make Bassa ready for Kubernetes deployments

### DIFF
--- a/components/core/Killer.py
+++ b/components/core/Killer.py
@@ -1,6 +1,6 @@
 import urllib.request, urllib.error, urllib.parse
 
-req = urllib.request.Request('http://localhost:5000/download/kill')
+req = urllib.request.Request('https://192.168.64.9/api/download/kill')
 req.add_header('key', '123456789')
 resp = urllib.request.urlopen(req)
 content = resp.read()

--- a/components/core/Killer.py
+++ b/components/core/Killer.py
@@ -1,6 +1,6 @@
 import urllib.request, urllib.error, urllib.parse
 
-req = urllib.request.Request('https://192.168.64.9/api/download/kill')
+req = urllib.request.Request('http://localhost:5000/download/kill')	
 req.add_header('key', '123456789')
 resp = urllib.request.urlopen(req)
 content = resp.read()

--- a/components/core/Server.py
+++ b/components/core/Server.py
@@ -27,8 +27,8 @@ def serve_ui1():
 
 
 # download endpoints
-server.add_url_rule(rule='/download/start', endpoint='start', view_func=Download.start)
-server.add_url_rule(rule='/download/kill', endpoint='kill', view_func=Download.kill)
+server.add_url_rule(rule='/api/download/start', endpoint='start', view_func=Download.start)
+server.add_url_rule(rule='/api/download/kill', endpoint='kill', view_func=Download.kill)
 server.add_url_rule(rule='/api/download', endpoint='add_download_request', view_func=Download.add_download_request,
 					methods=['POST'])
 server.add_url_rule(rule='/api/download/<int:id>', endpoint='remove_download_request',

--- a/components/core/Starter.py
+++ b/components/core/Starter.py
@@ -1,6 +1,7 @@
 import urllib.request, urllib.error, urllib.parse
 
-req = urllib.request.Request('http://localhost:5000/download/start')
+req = urllib.request.Request('
+  .value('BassaUrl', 'https://192.168.64.9/api/download/start')
 req.add_header('key', '123456789')
 resp = urllib.request.urlopen(req)
 content = resp.read()

--- a/components/core/Starter.py
+++ b/components/core/Starter.py
@@ -1,7 +1,6 @@
 import urllib.request, urllib.error, urllib.parse
 
-req = urllib.request.Request('
-  .value('BassaUrl', 'https://192.168.64.9/api/download/start')
+req = urllib.request.Request('http://localhost:5000/download/start')
 req.add_header('key', '123456789')
 resp = urllib.request.urlopen(req)
 content = resp.read()

--- a/components/core/dl.conf
+++ b/components/core/dl.conf
@@ -1,1 +1,1 @@
-{"max_downloads": 2, "down_folder": "../../downloads", "size_limit":100000, "max_age":1, "min_rating":3, "max_bandwidth": 300000, "aria_server": "ws://aria2c:6800/jsonrpc", "tmp_folder": "/tmp/bassa/"}
+{"max_downloads": 2, "down_folder": "../../downloads", "size_limit":100000, "max_age":1, "min_rating":3, "max_bandwidth": 300000, "aria_server": "ws://localhost:6800/jsonrpc", "tmp_folder": "/tmp/bassa/"}

--- a/components/database/dockerfile
+++ b/components/database/dockerfile
@@ -1,0 +1,5 @@
+FROM mysql:5.7
+COPY ../../db_schema/Bassa.sql /tmp/schema/
+COPY ../../.docker/volumes/mysql/create-schema.sh /docker-entrypoint-initdb.d/
+EXPOSE 3306
+CMD ["mysqld"]

--- a/scripts/kubernetes/deploy.sh
+++ b/scripts/kubernetes/deploy.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+if [ "$1" = "delete" ]; then
+    echo "Clearing the cluster."
+    kubectl delete -f ./manifests/web/00-namespace.yml
+    echo "Bassa is removed from the cluster"
+elif [ "$1" = "create" ]; then
+    echo "Deploying Bassa to kubernetes cluster"
+    # Deploy web pod
+    kubectl create -R -f ./manifests/web/
+    # Deploy api and aria2c pod
+    kubectl create -R -f ./manifests/api_and_aria2c/
+    # Deploy database pod
+    kubectl create -R -f ./manifests/database/
+    echo "Bassa got deployed at"
+    kubectl get ingress -n bassa | awk '{ print $3 }'
+fi

--- a/scripts/kubernetes/manifests/api_and_aria2c/deployment.yml
+++ b/scripts/kubernetes/manifests/api_and_aria2c/deployment.yml
@@ -1,0 +1,43 @@
+kind: Deployment
+apiVersion: apps/v1beta1
+metadata:
+  name: api
+  namespace: bassa
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: api
+    spec:
+      volumes:
+      - name: downloads
+        persistentVolumeClaim:
+          claimName: downloads-claim  
+      containers:
+      - name: api
+        image: kmehant/api
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 5000
+          protocol: TCP
+        env:
+        - name: BASSA_DB_NAME
+          value: 'Bassa'
+        - name: BASSA_DB_USERNAME
+          value: 'bassa'
+        - name: BASSA_DB_PASSWORD
+          value: 'bassa@1234'
+        volumeMounts:
+        - mountPath: /downloads
+          name: downloads
+      - name: aria2c
+        image: kmehant/aria2c
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 6800
+          protocol: TCP
+        volumeMounts:
+        - mountPath: /data
+          name: downloads
+      restartPolicy: Always

--- a/scripts/kubernetes/manifests/api_and_aria2c/downloads-claim.yml
+++ b/scripts/kubernetes/manifests/api_and_aria2c/downloads-claim.yml
@@ -1,0 +1,11 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: downloads-claim
+  namespace: bassa
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 250Mi

--- a/scripts/kubernetes/manifests/api_and_aria2c/service.yml
+++ b/scripts/kubernetes/manifests/api_and_aria2c/service.yml
@@ -1,0 +1,12 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: api
+  namespace: bassa
+spec:
+  ports:
+  - port: 5000
+    protocol: TCP
+    targetPort: 5000
+  selector:
+    app: api

--- a/scripts/kubernetes/manifests/database/database-claim.yml
+++ b/scripts/kubernetes/manifests/database/database-claim.yml
@@ -1,0 +1,11 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: database-claim
+  namespace: bassa
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 250Mi

--- a/scripts/kubernetes/manifests/database/deployment.yml
+++ b/scripts/kubernetes/manifests/database/deployment.yml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: db
+  namespace: bassa
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: db
+    spec:
+      containers:
+        - name: db
+          image: kmehant/db
+          imagePullPolicy: Always
+          env:
+            - name: MYSQL_ROOT_PASSWORD
+              value: bassa@1234
+            - name: MYSQL_DATABASE
+              value: Bassa
+            - name: MYSQL_USER
+              value: bassa
+            - name: BASSA_DB_NAME
+              value: Bassa
+            - name: MYSQL_PASSWORD
+              value: bassa@1234
+          ports:
+            - containerPort: 3306
+          volumeMounts:
+            - mountPath: /var/lib/mysql
+              name: data-volume
+      volumes:
+        - name: data-volume
+          persistentVolumeClaim:
+            claimName: database-claim         

--- a/scripts/kubernetes/manifests/database/service.yml
+++ b/scripts/kubernetes/manifests/database/service.yml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: db
+  namespace: bassa
+  labels:
+    name: db
+spec:
+  ports:
+    - port: 3306
+  selector:
+    name: db

--- a/scripts/kubernetes/manifests/web/00-namespace.yml
+++ b/scripts/kubernetes/manifests/web/00-namespace.yml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: bassa

--- a/scripts/kubernetes/manifests/web/deployment.yml
+++ b/scripts/kubernetes/manifests/web/deployment.yml
@@ -1,0 +1,20 @@
+kind: Deployment
+apiVersion: apps/v1beta1
+metadata:
+  name: web
+  namespace: bassa
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: web
+    spec:
+      containers:
+      - name: web
+        image: kmehant/web
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 80
+          protocol: TCP
+      restartPolicy: Always

--- a/scripts/kubernetes/manifests/web/ingress.yml
+++ b/scripts/kubernetes/manifests/web/ingress.yml
@@ -1,0 +1,17 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: web-ingress
+  namespace: bassa
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /
+        backend:
+          serviceName: web
+          servicePort: 80
+      - path: /api/
+        backend:
+          serviceName: api
+          servicePort: 5000

--- a/scripts/kubernetes/manifests/web/service.yml
+++ b/scripts/kubernetes/manifests/web/service.yml
@@ -1,0 +1,12 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: web
+  namespace: bassa
+spec:
+  ports:
+  - port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    app: web

--- a/ui/config.ts
+++ b/ui/config.ts
@@ -1,0 +1,3 @@
+export var config = {
+    "API_URL":"http://localhost:5000",
+  }

--- a/ui/src/app/admin/services/AdminService.js
+++ b/ui/src/app/admin/services/AdminService.js
@@ -8,7 +8,7 @@
     var startDownloads = function() {
       return $http({
           method: 'GET',
-          url: BassaUrl + '/download/start',
+          url: BassaUrl + '/api/download/start',
           headers: {'key': '123456789'}
       });
     };
@@ -16,7 +16,7 @@
     var killDownloads = function() {
       return $http({
         method: 'GET',
-        url: BassaUrl + '/download/kill',
+        url: BassaUrl + '/api/download/kill',
         headers: {'key': '123456789'}
       });
     };

--- a/ui/src/app/admin/services/AdminService.spec.js
+++ b/ui/src/app/admin/services/AdminService.spec.js
@@ -18,7 +18,7 @@ describe("Service: AdminService", function() {
 
   it("should start downloads", function() {
 
-    localHttpBackend.expect("GET", localBassaUrl + "/download/start")
+    localHttpBackend.expect("GET", localBassaUrl + "/api/download/start")
       .respond(201, { "status": "12345" });
 
     AdminService.startDownloads().then(function(response) {
@@ -31,7 +31,7 @@ describe("Service: AdminService", function() {
 
   it("should kill downloads", function() {
     
-    localHttpBackend.expect("GET", localBassaUrl + "/download/kill")
+    localHttpBackend.expect("GET", localBassaUrl + "/api/download/kill")
         .respond(200, { status: "success"});
   
     AdminService.killDownloads().then(function(response) {

--- a/ui/src/app/index.js
+++ b/ui/src/app/index.js
@@ -3,7 +3,7 @@
 angular.module('bassa', ['ngAnimate', 'ngCookies', 'ngTouch',
   'ngSanitize', 'ui.router', 'ngMaterial', 'nvd3', 'app'])
 
-  .value('BassaUrl', 'http://localhost:5000')
+  .value('BassaUrl', 'https://192.168.64.9')
 
   .config(function ($stateProvider, $httpProvider, $urlRouterProvider, $mdThemingProvider,
                     $mdIconProvider, $qProvider) {

--- a/ui/src/app/index.js
+++ b/ui/src/app/index.js
@@ -1,9 +1,10 @@
 'use strict';
+import { config } from "../../config";
 
 angular.module('bassa', ['ngAnimate', 'ngCookies', 'ngTouch',
   'ngSanitize', 'ui.router', 'ngMaterial', 'nvd3', 'app'])
 
-  .value('BassaUrl', 'https://192.168.64.9')
+  .value('BassaUrl', config.API_URL)
 
   .config(function ($stateProvider, $httpProvider, $urlRouterProvider, $mdThemingProvider,
                     $mdIconProvider, $qProvider) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Written kubernetes configurations for Bassa API server, Bassa Angular client, database and aria2c. 

## Overview 
Web and Bassa database will be in separate pods, whereas aria2c and API server will be in a single pod sharing a common persistent volume for downloaded files. Bassa database uses another persistent volume for the database. Coming to hostnames, as Bassa API server and Aria2c server stays in the same pod so they communicate using the localhost hostname. API server communicates to the database through the hostname `db` which is being resolved by Kubernetes DNS. There is a problem for communication between Bassa UI and Bassa API server and presently shall use ingress for Bassa Web client to communicate with API server. Coming to persistent volumes which have to be replaced with other cloud-based options like AWS, GCE, and others. Need some suggestion to find a best way for communication between API and Web.

## Related Issue
#769 

## Motivation and Context
We need to integrate the orchestration tool Kubernetes to Bassa for better on-premise deployments.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
