### PR TITLE
update version of Gulp-Sass

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -78,7 +78,7 @@
     "gulp-rev": "~2.0.1",
     "gulp-rev-replace": "~0.3.1",
     "gulp-ruby-sass": "~0.7.1",
-    "gulp-sass": "^2.3.2",
+    "gulp-sass": "^3.1.0",
     "gulp-size": "~1.1.0",
     "gulp-uglify": "3.0.0",
     "gulp-uglify-es": "^1.0.4",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
the version 2.3 of gulp-sass is causing errors 
"Node Sass does not yet support your current environment: OS X 64-bit with Unsupported runtime (64)"
on setting up the project on OSX 

## Related Issue #852 

## Motivation and Context
this change to version 3.1.0 of gulp sass helps solve the issue of the node sass version being unsupported on the OSX platform having configuration of 64-bit

## How Has This Been Tested?
the errors didn't come after upgrading

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
