### PR TITLE
Added .gitignore to downloads folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,7 +88,7 @@ __pycache__/
 build/
 develop-eggs/
 dist/
-downloads/
+#downloads/
 eggs/
 .eggs/
 lib/

--- a/downloads/.gitignore
+++ b/downloads/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/downloads/.gitignore
+++ b/downloads/.gitignore
@@ -1,2 +1,6 @@
+# Downloads folder is reserved for user-specific downloads.
+# Developer should not push local downloads to remote upstream.
+# All contents of the folder will be ignored, other than this file.
+
 *
 !.gitignore

--- a/downloads/data.txt
+++ b/downloads/data.txt
@@ -1,2 +1,0 @@
-This folder contains downloaded data from Aria2c 
-which is mapped to both Bassa API container and Aria2c RPC server


### PR DESCRIPTION
## Description
All files in the downloads folder are ignored when pushing to remote branch. This prevents user-downloaded files from showing up in future PRs.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#857

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
GCI 2019 task.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested by creating files with multiple different extensions in the downloads folder, and then trying to push them.

## Screenshots (In case of UI changes):
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
