### PR TITLE
Pushed empty downloads folder to Bassa GitHub Repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 
 # Created by https://www.gitignore.io/api/vim,node,python,sublimetext,visualstudiocode
 
+### Mac Junk ###
+.DS_Store
+
 ### Node ###
 # Logs
 logs
@@ -42,7 +45,7 @@ jspm_packages/
 
 *.log
 components/core/debug-server.log
-downloads/
+
 
 # UI
 ui/dist
@@ -85,7 +88,7 @@ __pycache__/
 build/
 develop-eggs/
 dist/
-downloads/
+#downloads/
 eggs/
 .eggs/
 lib/
@@ -225,5 +228,10 @@ tags
 !.vscode/launch.json
 !.vscode/extensions.json
 .history
+
+### IDEs
+
+.idea/*
+.vscode/*
 
 # End of https://www.gitignore.io/api/vim,node,python,sublimetext,visualstudiocode

--- a/downloads/.gitignore
+++ b/downloads/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/downloads/.gitignore
+++ b/downloads/.gitignore
@@ -1,4 +1,3 @@
-# Ignore everything in this directory
-*
-# Except this file
+# Pushed empty folder in the downloads folder 
+# ignore this file 
 !.gitignore

--- a/downloads/.gitignore
+++ b/downloads/.gitignore
@@ -1,3 +1,4 @@
-# Pushed empty folder in the downloads folder 
-# ignore this file 
-!.gitignore
+# Made empty folder(downloads) in the github folder
+
+*
+!.gitignore 


### PR DESCRIPTION
Pushed empty downloads folder to Bassa GitHub Repository

## Description
Made a downloads folder and added .gitignore file

## Related Issue
Find a better way to push the empty download folder without the present placeholder (data.txt) and should also ignore the downloaded files in commits.

## Motivation and Context
This way it gives us benefit that files in that directory won't show up as "untracked" when you do a git status.

## How Has This Been Tested?
Checked by running git status on terminal

## Screenshots (In case of UI changes):
-NA-

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
