### PR TITLE
Pushed empty downloads folder to Bassa GitHub Repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,7 +85,7 @@ __pycache__/
 build/
 develop-eggs/
 dist/
-downloads/
+# downloads/
 eggs/
 .eggs/
 lib/

--- a/downloads/.gitignore
+++ b/downloads/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore 

--- a/downloads/.gitignore
+++ b/downloads/.gitignore
@@ -1,2 +1,4 @@
+# Ignore everything in this directory
 *
-!.gitignore 
+# Except this file
+!.gitignore


### PR DESCRIPTION
Pushed empty downloads folder to Bassa GitHub Repository

## Description
Made a downloads folder and added .gitignore file
## Related Issue
Find a better way to push the empty download folder without the present placeholder (data.txt) and should also ignore the downloaded files in commits.

## Motivation and Context
This way it gives us benefit that files in that directory won't show up as "untracked" when you do a git status.

## How Has This Been Tested?
Checked by running git status on terminal


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
