### PR TITLE
Download

### DIFF
--- a/downloads/.gitignore
+++ b/downloads/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/downloads/data.txt
+++ b/downloads/data.txt
@@ -1,2 +1,0 @@
-This folder contains downloaded data from Aria2c 
-which is mapped to both Bassa API container and Aria2c RPC server


### PR DESCRIPTION
Pushed empty downloads folder to Bassa GitHub Repository

## Description
Made a downloads folder and added .gitignore file

## Related Issue
Find a better way to push the empty download folder without the present placeholder (data.txt) and should also ignore the downloaded files in commits.
## Motivation and Context
This way it gives us benefit that files in that directory won't show up as "untracked" when you do a git status.

## How Has This Been Tested?
Checked by running git status on terminal

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
