### PR TITLE
Pushed empty downloads folder to Bassa GitHub Repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,7 +88,6 @@ __pycache__/
 build/
 develop-eggs/
 dist/
-downloads/
 eggs/
 .eggs/
 lib/

--- a/downloads/.gitignore
+++ b/downloads/.gitignore
@@ -1,0 +1,5 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore
+

--- a/downloads/data.txt
+++ b/downloads/data.txt
@@ -1,2 +1,0 @@
-This folder contains downloaded data from Aria2c 
-which is mapped to both Bassa API container and Aria2c RPC server


### PR DESCRIPTION
This pull request implements a Git best practice for managing an empty directory that needs to persist in the repository:

Removes the blanket ignore of the downloads/ folder from the root .gitignore
Creates a nested .gitignore inside the downloads/ folder that ignores everything except itself
Maintains folder structure in version control while excluding actual downloaded content
This pattern allows:

✅ The downloads/ directory to exist in the repository
✅ Developers to have an empty downloads/ folder after cloning
✅ Actual downloaded data to remain local (ignored by .gitignore)
✅ Proper initialization of the directory for the Aria2c download manager