### PR TITLE
Configured GitHub to style unstyled or unrecognized files in repository 

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -29,6 +29,7 @@
 *.pyc 		binary
 *.pyd		binary
 *.pyo 		binary
+*.lock    binary
 
 ## SOURCE CODE
 *.bat      text eol=crlf
@@ -42,6 +43,7 @@
 *.json     text
 *.jsx      text
 *.less     text
+*.env      text
 *.od       text
 *.onlydata text
 *.php      text
@@ -59,10 +61,13 @@
 *.tsx      text
 *.xml      text
 *.xhtml    text
+*.spec     text
+*.prettierrc   text
 
 ## DOCKER
 *.dockerignore    text
-Dockerfile    text
+Dockerfile        text
+Docker-compose    text
 
 ## DOCUMENTATION
 *.markdown   text
@@ -74,6 +79,8 @@ Dockerfile    text
 *.mdtxt      text
 *.mdtext     text
 *.txt        text
+*.prod       text
+*.sample     text
 AUTHORS      text
 CHANGELOG    text
 CHANGES      text
@@ -104,6 +111,7 @@ TODO         text
 *.tmpl       text
 *.tpl        text
 *.twig       text
+*.dev        text
 
 ## LINTERS
 .csslintrc    text


### PR DESCRIPTION
Configured GitHub to style unstyled or unrecognized files in repository 

## Description
Added file extensions in .gitattributes file whichever weren't there

## Motivation and Context
This way all the files whether they be unstyled or unrecognized will now be styled

## How Has This Been Tested?
Tested on my local system

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
