### PR TITLE
Configured GitHub to style unstyled or unrecognized files in repository

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -29,11 +29,13 @@
 *.pyc 		binary
 *.pyd		binary
 *.pyo 		binary
+*.prod    binary
 
 ## SOURCE CODE
 *.bat      text eol=crlf
 *.coffee   text
 *.css      text
+*.env      text
 *.htm      text
 *.html     text
 *.inc      text
@@ -63,8 +65,10 @@
 ## DOCKER
 *.dockerignore    text
 Dockerfile    text
+Docker-compose    text
 
 ## DOCUMENTATION
+*.dev        text
 *.markdown   text
 *.md         text
 *.mdwn       text
@@ -73,6 +77,7 @@ Dockerfile    text
 *.mkdn       text
 *.mdtxt      text
 *.mdtext     text
+*.sample     text
 *.txt        text
 AUTHORS      text
 CHANGELOG    text


### PR DESCRIPTION
Configured GitHub to style unstyled or unrecognized files in repository

## Description
Added file extensions in .gitattributes file whichever weren't there

## Motivation and Context
This way all the files whether they be unstyled or unrecognized will now be styled

## How Has This Been Tested?
Tested on my local system

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
