### PR TITLE
Configured GitHub to style unstyled or unrecognized files in repository

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -34,6 +34,8 @@
 *.bat      text eol=crlf
 *.coffee   text
 *.css      text
+*.conf     linguist-language=xml
+*.env      linguist-language=python
 *.htm      text
 *.html     text
 *.inc      text
@@ -46,6 +48,7 @@
 *.onlydata text
 *.php      text
 *.pl       text
+*.prettierrc   linguist-language=java-script
 *.py       text
 *.rb       text
 *.sass     text
@@ -63,8 +66,11 @@
 ## DOCKER
 *.dockerignore    text
 Dockerfile    text
+*.prod        linguist-language=dockerfile
+*.Docker-compose    linguist-language=dockerfile
 
 ## DOCUMENTATION
+*.dev        text
 *.markdown   text
 *.md         text
 *.mdwn       text
@@ -74,6 +80,7 @@ Dockerfile    text
 *.mdtxt      text
 *.mdtext     text
 *.txt        text
+*.env        text
 AUTHORS      text
 CHANGELOG    text
 CHANGES      text
@@ -162,6 +169,7 @@ makefile       text
 *.mp3  binary
 *.ogg  binary
 *.ra   binary
+*.sample  binary
 
 ## VIDEO
 *.3gpp binary


### PR DESCRIPTION
Configured GitHub to style unstyled or unrecognized files in repository

## Description
Added file extensions in .gitattributes file whichever weren't there

## Motivation and Context
This way all the files whether they be unstyled or unrecognized will now be styled

## How Has This Been Tested?
Tested on my local system

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
