### PR TITLE
[FIX:872] Corrected websocket server url

### DIFF
--- a/components/core/dl.conf
+++ b/components/core/dl.conf
@@ -1,1 +1,1 @@
-{"max_downloads": 2, "down_folder": "../../downloads", "size_limit":100000, "max_age":1, "min_rating":3, "max_bandwidth": 300000, "aria_server": "ws://aria2c:6800/jsonrpc", "tmp_folder": "/tmp/bassa/"}
+{"max_downloads": 2, "down_folder": "../../downloads", "size_limit":100000, "max_age":1, "min_rating":3, "max_bandwidth": 300000, "aria_server": "ws://localhost:6800/jsonrpc", "tmp_folder": "/tmp/bassa/"}


### PR DESCRIPTION
## Description
Earlier, websockets were unable to connect to *aria2c* server. Problem behind this was **aria_server** key value in dl.conf. So replaced old value by `ws://localhost:6800/jsonrpc`.
 If `aria2c` is used for deployment, then we should make different keys for development and deployment.

## Related Issue
#872 .
<!--- Please link to the issue here: -->

## Motivation and Context
In development environment our hostname is `localhost`.

## How Has This Been Tested?
Now no error named as `Name or service is getting produced`, in fact now websocket gets successfully connected to aria2c server. But there are some new errors being produced which i guess related to #806. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Note
Do run `sudo python3 setup develop` to refresh **~/.config/bassa/dl.conf**.