### PR TITLE
[FIX] Download on clicking start button

### DIFF
--- a/components/core/DownloadDaemon.py
+++ b/components/core/DownloadDaemon.py
@@ -33,7 +33,6 @@ class Handler(queue.Queue):
         queue.Queue.__init__(self)
         self.ws = ws
         self.num_workers = 5
-        self.start_workers()
 
     def add_to_queue(self, download):
         self.put(download)
@@ -67,7 +66,7 @@ class Handler(queue.Queue):
 
 class MessageHandler():
 
-    def __init__(self,ws):
+    def __init__(self, ws):
         self.num_workers = 5
         self.ws = ws
 
@@ -135,7 +134,7 @@ class MessageHandler():
                     get_status(self.ws, None, data['params'][0]['gid'])
                     db_lock.release()
                     messageQueue.task_done()
-            
+
 class RepeatedTimer(object):
     def __init__(self, interval, function, *args, **kwargs):
         self._timer     = None
@@ -240,8 +239,7 @@ def on_error(ws, error):
 
 
 def on_close(ws):
-    pass
-
+    logging.info("Socket closed")
 
 def on_open(ws):
     initialize(ws)
@@ -259,13 +257,13 @@ def starter(socket):
                                 on_close=on_close)
     ws.on_open = on_open
     handler = Handler(ws)
+    handlerLst.append(handler)
     # socketio.emit("test", {'data': 'A NEW FILE WAS POSTED'}, namespace='/news')
     threading.Thread(target=handler.start_workers).start()
-    mHandler = MessageHandler(ws) 
+    mHandler = MessageHandler(ws)
     threading.Thread(target=mHandler.start_message_workers).start()
     messageQueue.join()
     ws.run_forever()
-
 
 
 

--- a/components/core/Server.py
+++ b/components/core/Server.py
@@ -27,8 +27,8 @@ def serve_ui1():
 
 
 # download endpoints
-server.add_url_rule(rule='/download/start', endpoint='start', view_func=Download.start)
-server.add_url_rule(rule='/download/kill', endpoint='kill', view_func=Download.kill)
+server.add_url_rule(rule='/download/start', endpoint='start', view_func=Download.start, methods=['GET'])
+server.add_url_rule(rule='/download/kill', endpoint='kill', view_func=Download.kill, methods=['GET'])
 server.add_url_rule(rule='/api/download', endpoint='add_download_request', view_func=Download.add_download_request,
 					methods=['POST'])
 server.add_url_rule(rule='/api/download/<int:id>', endpoint='remove_download_request',
@@ -40,7 +40,7 @@ server.add_url_rule(rule='/api/downloads/<int:limit>', endpoint='get_downloads_r
 server.add_url_rule(rule='/api/download/<int:id>', endpoint='get_download', view_func=Download.get_download,
 					methods=['GET'])
 server.add_url_rule(rule='/api/file_from_minio/<int:id>', endpoint='get_file_from_minio', view_func=Download.get_file_from_minio,
-					methods=['GET'])			
+					methods=['GET'])
 
 # user action api endpoints
 server.add_url_rule(rule='/api/login', endpoint='login', view_func=User.login, methods=['POST'])


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
- Added code to append `handler` to `handlerLst`.
- Added log for socket close.
- Added `Start` and `Kill` endpoint's method (**GET**).

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#806 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Empty handler list leads to infinite loop which in turn disable the download. In started function a handler is created which should be appended to `handlerLst`.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Now files are successfully downloaded requested by any user. Pie chart screenshot: 
![Screenshot from 2020-01-31 15-28-01](https://user-images.githubusercontent.com/42354803/73530361-556ba300-443e-11ea-848b-5ddcc4fa40fb.png)
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
