### PR TITLE
[FIX] Changed Logout menu to button

### DIFF
--- a/ui/src/app/views/main.html
+++ b/ui/src/app/views/main.html
@@ -26,14 +26,9 @@
           <p>Hi {{username}}</p>
         </section>
         <section layout-align="end center">
-            <md-menu md-offset="0 20">
-                <md-button class="capitalize" ng-click="$mdOpenMenu()" aria-label="Open menu">
-                <i class="material-icons">menu</i>
-                </md-button>
-                <md-menu-content width="2">
-                    <md-menu-item><md-button ng-click="logout()" ui-sref="login">Logout <i class="fa fa-power-off" style="color:maroon"></i> </md-button></md-menu-item>
-                </md-menu-content>
-            </md-menu>
+            <md-button ng-click="logout()" ui-sref="login">
+            <md-tooltip> Log out </md-tooltip>
+            <i class="fa fa-power-off" style="color:maroon"></i> </md-button>
         </section>
     </md-toolbar>
 


### PR DESCRIPTION
## Description
Log out button was enclosed in menu, which is basically overhead for user. In fact, `Hi _name_` would be covered by menu. So removed menu, and simply placed log out icon as button with tooltip `Log out`. 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
fixes #717 

## Motivation and Context
Menu covers the `Hi _name_` as given in above referenced issue. And it's kinda overhead containing only Log out button.

## Screenshots (In case of UI changes):
![Screenshot from 2020-02-04 19-08-53](https://user-images.githubusercontent.com/42354803/73749689-dbab2080-4781-11ea-88da-6ee67c321c2f.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
