### PR TITLE
[Feat] Reset password to null 

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,12 @@
+# These are supported funding model platforms
+
+github: # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
+patreon: # Replace with a single Patreon username
+open_collective: # Replace with a single Open Collective username
+ko_fi: # Replace with a single Ko-fi username
+tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
+community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry
+liberapay: # Replace with a single Liberapay username
+issuehunt: # Replace with a single IssueHunt username
+otechie: # Replace with a single Otechie username
+custom: # Replace with a single custom sponsorship URL

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -2,7 +2,7 @@
 
 github: # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
 patreon: # Replace with a single Patreon username
-open_collective: agentmilindu
+open_collective: bassa
 ko_fi: # Replace with a single Ko-fi username
 tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
 community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -2,7 +2,7 @@
 
 github: # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
 patreon: # Replace with a single Patreon username
-open_collective: # Replace with a single Open Collective username
+open_collective: agentmilindu
 ko_fi: # Replace with a single Ko-fi username
 tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
 community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,38 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
+
+**Smartphone (please complete the following information):**
+ - Device: [e.g. iPhone6]
+ - OS: [e.g. iOS8.1]
+ - Browser [e.g. stock browser, safari]
+ - Version [e.g. 22]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/ui/src/app/login/controllers/LoginCtrl.js
+++ b/ui/src/app/login/controllers/LoginCtrl.js
@@ -16,6 +16,8 @@
           $scope.unApproved = true;
         } else if(status.state == 403) {
           $scope.incorrectCredentials = true;
+          $scope.user.password = '';
+          $scope.loginForm.password.$setTouched();
         }
        });
     };

--- a/ui/src/app/views/login.html
+++ b/ui/src/app/views/login.html
@@ -1,13 +1,33 @@
 <div layout="column" layout-align="center center">
     <img class="logo" ng-src="assets/images/logo.png">
-    <div layout="column" class="login-content">
+    <form name="loginForm" style="all: unset !important;width: 23% !important">
+        <div layout="column">
+            <md-input-container class="input-container">
+                <label>User name</label>
+                <input type="text" ng-model="user.user_name" name="user_name" ng-required="true" />
+            </md-input-container>
+            <md-input-container class="input-container">
+                <label>Password</label>
+                <input type="password" ng-model="user.password" ng-required="true" ng-enter="login()" name="password" />
+            </md-input-container>
+            <md-button class="md-raised md-primary login-button" ng-disabled="loginForm.$invalid" ng-click="login();">Login</md-button>
+            <div layout="row">
+                <p>Don't have an account?</p>
+                <a class="" id="signup-button" ng-click="signup()">Signup</a>
+            </div>
+            <br>
+        </div>
+    </form>
+
+    <!-- <div layout="column" class="login-content">
         <md-input-container class="input-container">
-            <label>User name</label>
-            <input type="text" ng-model="user.user_name" />
+            <label id="user_name_label">User name</label>
+            <input type="text" ng-model="user.user_name" id="user_name" ng-required="true" />
+            <span ng-show="user.user_name.$touched"> User name is required </span>
         </md-input-container>
         <md-input-container class="input-container">
-            <label>Password</label>
-            <input type="password" ng-model="user.password" ng-enter="login()" />
+            <label id="password_label">Password</label>
+            <input type="password" ng-model="user.password" ng-required="true" ng-enter="login()" id="password" />
         </md-input-container>
         <md-button class="md-raised md-primary login-button" ng-click="login()">Login</md-button>
         <div layout="row">
@@ -15,7 +35,8 @@
             <a class="" id="signup-button" ng-click="signup()">Signup</a>
         </div>
         <br>
-    </div>
+    </div> -->
+
     <div class="alert" ng-if="incorrectCredentials">
         <span class="closebtn msg" onclick="this.parentElement.style.display='none';">&times;</span> Incorrect Credentials
     </div>


### PR DESCRIPTION
Description
After an unsuccessful login password have to be reset to null with highlighting the password container. Form validations are added and the login button will enable only if both user name and password are provided.

Related Issue
#906 

Motivation and Context
Password will be reset to null after an invalid login.

How Has This Been Tested?
Manually tested by inputting wrong credentials.

Screenshots (In case of UI changes):
![bassa1](https://user-images.githubusercontent.com/43112139/77863600-37090480-7241-11ea-8df0-b48fa02ef489.gif)



Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
