### PR TITLE
Fixed the broken logo in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <hr>
 
-![logo](http://gdurl.com/7XYK)
+![Bassa logo](https://github.com/scorelab/Bassa/blob/master/ui/src/assets/images/bassa.png?raw=true)
 
 [![Build Status](https://travis-ci.org/scorelab/Bassa.svg?branch=master)](https://travis-ci.org/scorelab/Bassa)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/7de63c7b9a69448787e8014a12a260b1)](https://www.codacy.com/app/SCoRe-Lab/Bassa?utm_source=github.com&utm_medium=referral&utm_content=scorelab/Bassa&utm_campaign=badger)

--- a/README.md
+++ b/README.md
@@ -54,9 +54,8 @@ You can also discuss about other projects on [SCoRe Lab gitter channel](https://
 
 ## Contributors
 
-This project exists thanks to all the people who contribute. 
-<a href="https://opencollective.com/Bassa#contributors" target="_blank"><img src="https://opencollective.com/Bassa/contributors.svg?width=890&button=false" /></a>
-
+This project exists thanks to all the people who contribute.
+[![Contributors Image](https://opencollective.com/Bassa/contributors.svg?width=890&button=false)](https://opencollective.com/Bassa#contributors)
 
 ## Backers
 


### PR DESCRIPTION
## Description
The Bassa logo in the README was broken. I fixed that. Also, the Contributors section in the README file was ported from HTML to standard Markdown.

## Related Issue
The issue referenced is #693 and #894 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
