### PR TITLE
Feat: added download starting date

### DIFF
--- a/ui/src/app/views/dashboard.html
+++ b/ui/src/app/views/dashboard.html
@@ -18,6 +18,7 @@
         <tr ng-repeat="data in downloads">
             <td id="vertalign" data-title="ID">{{$index + 1}}</td>
             <td id="vertalign" data-title="Issue">{{data.download_name}}</td>
+            <td id="vertalign" data-title="DateTime">{{data.added_time | date:"MM/dd/yyyy 'at' h:mma"}}</td>
             <td id="vertalign" data-title="Progress">
               <md-progress-linear
                 md-mode="determinate"
@@ -36,4 +37,3 @@
   </md-content>
 
 </div>
-


### PR DESCRIPTION
Description
Added starting date and time along with the downloading item.

Related Issue
#913 

Motivation and Context
Starting date and time have to be displayed along with the downloading item.

How Has This Been Tested?
Manually tested by adding a new link to be downloaded.

Screenshots (In case of UI changes):


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
